### PR TITLE
bugfix in installGithubPackage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: A single key function, 'Require' that makes rerun-tolerant
 URL: 
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
-Date: 2022-10-15
-Version: 0.1.6.9008
+Date: 2022-10-25
+Version: 0.1.6.9009
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@canada.ca",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/R/Require-helpers.R
+++ b/R/Require-helpers.R
@@ -2049,8 +2049,8 @@ installGithubPackage <- function(gitRepo, libPath = .libPaths()[1], verbose = ge
       if (is(shaOnGitHub, "try-error")) {
         useRemotes <- TRUE
       } else {
-        shaLocal <- DESCRIPTIONFileOtherV(alreadyExistingDESCRIPTIONFile, other = "GithubSHA1")
-        if (identical(unname(shaLocal), unname(shaOnGitHub))) {
+        shaLocal <- DESCRIPTIONFileOtherV(alreadyExistingDESCRIPTIONFile[filesExist], other = "GithubSHA1")
+        if (identical(unname(shaLocal[filesExist]), unname(shaOnGitHub[filesExist]))) {
           messageVerbose("Skipping install of ", gitRepo, ", the SHA1 has not changed from last install",
                          verbose = verbose, verboseLevel = 1)
           return(invisible())


### PR DESCRIPTION
Fixing this:

When (>=) 2 packages are being installed from GitHub, if one is already installed, but the other one isn't this `filesExist <- file.exists(unlist(alreadyExistingDESCRIPTIONFile))` returns `[1] TRUE FALSE` which breaks this downstream:
`shaLocal <- DESCRIPTIONFileOtherV(alreadyExistingDESCRIPTIONFile, other = "GithubSHA1")` since one of the DESCRIPTION files does not exist.

ATTENTION:
CRAN build checks did not pass -- failure in first test script -- but I'm still unsure whether this is triggered by my changes.
```
> test_pkg("Require")
 --------------------------------- Starting testit/test-0pkgSnapshot.R  at: 2022-10-25 21:39:38.94---------------------------
 getOption('Require.verbose'): 2
 getOption('repos'): https://cloud.r-project.org/
Getting dates of current CRAN packages
Detaching is fraught with many potential problems; you may have torestart your session if things aren't working
-- Installing from:
  -- Archive: remotes, testit
-- 1:2 of 2. Estimated time left: ...; est. finish: ...calculating
installing older versions is still experimental and may cause package version conflicts
-- Determining dates on MRAN to get correct versions ... 
  2 of 2
Installing package into 'C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/d74oTr7P'
(as 'lib' is unspecified)
trying URL 'https://MRAN.revolutionanalytics.com/snapshot/2021-11-29/bin/windows/contrib/4.2/remotes_2.4.1.zip'
Content type 'application/zip' length 398634 bytes (389 KB)
==================================================
downloaded 389 KB

package 'remotes' successfully unpacked and MD5 sums checked
-- incorrect version installed from MRAN for testit; trying CRAN Archive (as source). Alternatively, try to manually increment the required version number to next version?
Warning: package 'testit' is in use and will not be installed
The following packages did not get installed correctly.
   packageFullName Package LibPath Version repoLocation installFrom
1: testit (==0.12)  testit    <NA>    <NA>      Archive     Archive
                                          installResult
1: package 'testit' is in use and will not be installed
Getting dependencies for 14 packages on CRAN
... 9 of these have recursive dependencies       
  9 of 9 Done!
Installing in groups to maintain dependencies: R6, askpass, covr, crayon, curl, digest, httr, jsonlite, lazyeval, mime, openssl, rex, sys, withr, yaml
-- Installing from:
  -- CRAN: R6, askpass, crayon, curl, digest, httr, jsonlite, lazyeval, mime, openssl, rex, sys, withr, yaml
-- 1:14 of 15 (grp 1 of 2). Estimated time left: ...; est. finish: ...calculating
Installing packages into 'C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/lHm4R7y0'
(as 'lib' is unspecified)
trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/R6_2.5.1.zip'
Content type 'application/zip' length 84265 bytes (82 KB)
==================================================
downloaded 82 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/askpass_1.1.zip'
Content type 'application/zip' length 72255 bytes (70 KB)
==================================================
downloaded 70 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/crayon_1.5.2.zip'
Content type 'application/zip' length 162539 bytes (158 KB)
==================================================
downloaded 158 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/curl_4.3.3.zip'
Content type 'application/zip' length 2492421 bytes (2.4 MB)
==================================================
downloaded 2.4 MB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/digest_0.6.29.zip'
Content type 'application/zip' length 194533 bytes (189 KB)
==================================================
downloaded 189 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/httr_1.4.4.zip'
Content type 'application/zip' length 519454 bytes (507 KB)
==================================================
downloaded 507 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/jsonlite_1.8.2.zip'
Content type 'application/zip' length 1105059 bytes (1.1 MB)
==================================================
downloaded 1.1 MB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/lazyeval_0.2.2.zip'
Content type 'application/zip' length 161543 bytes (157 KB)
==================================================
downloaded 157 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/mime_0.12.zip'
Content type 'application/zip' length 40621 bytes (39 KB)
==================================================
downloaded 39 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/openssl_2.0.3.zip'
Content type 'application/zip' length 2651109 bytes (2.5 MB)
==================================================
downloaded 2.5 MB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/rex_1.2.1.zip'
Content type 'application/zip' length 126622 bytes (123 KB)
==================================================
downloaded 123 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/sys_3.4.zip'
Content type 'application/zip' length 47040 bytes (45 KB)
==================================================
downloaded 45 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/withr_2.5.0.zip'
Content type 'application/zip' length 231681 bytes (226 KB)
==================================================
downloaded 226 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/yaml_2.3.5.zip'
Content type 'application/zip' length 116459 bytes (113 KB)
==================================================
downloaded 113 KB

package 'R6' successfully unpacked and MD5 sums checked
package 'askpass' successfully unpacked and MD5 sums checked
package 'crayon' successfully unpacked and MD5 sums checked
package 'curl' successfully unpacked and MD5 sums checked
package 'digest' successfully unpacked and MD5 sums checked
package 'httr' successfully unpacked and MD5 sums checked
package 'jsonlite' successfully unpacked and MD5 sums checked
package 'lazyeval' successfully unpacked and MD5 sums checked
package 'mime' successfully unpacked and MD5 sums checked
package 'openssl' successfully unpacked and MD5 sums checked
package 'rex' successfully unpacked and MD5 sums checked
package 'sys' successfully unpacked and MD5 sums checked
package 'withr' successfully unpacked and MD5 sums checked
package 'yaml' successfully unpacked and MD5 sums checked

The downloaded binary packages are in
	C:\Users\cbarros\AppData\Local\Temp\RtmpQJDSov\working_dir\RtmpyIXl5H\downloaded_packages
-- Installing from:
  -- Archive: covr
-- 15 of 15 (grp 2 of 2). Estimated time left: ...; est. finish: ...calculating
installing older versions is still experimental and may cause package version conflicts
-- Determining dates on MRAN to get correct versions ... 
Installing package into 'C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/lHm4R7y0'
(as 'lib' is unspecified)
trying URL 'https://MRAN.revolutionanalytics.com/snapshot/2022-08-26/bin/windows/contrib/4.2/covr_3.6.0.zip'
Content type 'application/zip' length 335124 bytes (327 KB)
==================================================
downloaded 327 KB

package 'covr' successfully unpacked and MD5 sums checked
All packages appear to have installed correctly
package version file saved in C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/d74oTr7P/packageVersions.txt

  There is a binary version available but the source version is later:
           binary source needs_compilation
data.table 1.14.2 1.14.4              TRUE

  Binaries will be installed
trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/data.table_1.14.2.zip'
Content type 'application/zip' length 2243013 bytes (2.1 MB)
==================================================
downloaded 2.1 MB

package 'data.table' successfully unpacked and MD5 sums checked

The downloaded binary packages are in
	C:\Users\cbarros\AppData\Local\Temp\RtmpQJDSov\working_dir\RtmpyIXl5H\downloaded_packages
 did not contain Require source code
package 'Require' successfully unpacked and MD5 sums checked
packageVersionFile is covering more than one library; installing packages in reverse order; also -- .libPaths() will be altered to be

                                                                        libPathInSnapshot
1: C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/d74oTr7P
2: C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/lHm4R7y0
                                                                                                                                                                  newLibPaths
1:                                                                                       C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/ASEZCK
2: C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/ASEZCK/C/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/lHm4R7y0
Using C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/RequireSnapshot/file6df0eb41d79; setting `require = FALSE`
Installing in groups to maintain dependencies: digest, lazyeval, mime, yaml
-- Installing from:
  -- CRAN: lazyeval, mime
-- 1:2 of 4 (grp 1 of 2). Estimated time left: ...; est. finish: ...calculating
Installing packages into 'C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/ASEZCK/C/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/lHm4R7y0'
(as 'lib' is unspecified)
trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/lazyeval_0.2.2.zip'
Content type 'application/zip' length 161543 bytes (157 KB)
==================================================
downloaded 157 KB

trying URL 'https://cloud.r-project.org/bin/windows/contrib/4.2/mime_0.12.zip'
Content type 'application/zip' length 40621 bytes (39 KB)
==================================================
downloaded 39 KB

package 'lazyeval' successfully unpacked and MD5 sums checked
package 'mime' successfully unpacked and MD5 sums checked

The downloaded binary packages are in
	C:\Users\cbarros\AppData\Local\Temp\RtmpQJDSov\working_dir\RtmpyIXl5H\downloaded_packages
-- Installing from:
  -- Archive: digest, yaml
-- 3:4 of 4 (grp 2 of 2). Estimated time left: ...; est. finish: ...calculating
installing older versions is still experimental and may cause package version conflicts
-- Determining dates on MRAN to get correct versions ... 
  2 of 2
Installing packages into 'C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/ASEZCK/C/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/lHm4R7y0'
(as 'lib' is unspecified)
trying URL 'https://MRAN.revolutionanalytics.com/snapshot/2022-09-10/bin/windows/contrib/4.2/digest_0.6.29.zip'
Content type 'application/zip' length 194511 bytes (189 KB)
==================================================
downloaded 189 KB

trying URL 'https://MRAN.revolutionanalytics.com/snapshot/2022-09-10/bin/windows/contrib/4.2/yaml_2.3.5.zip'
Content type 'application/zip' length 116457 bytes (113 KB)
==================================================
downloaded 113 KB

package 'digest' successfully unpacked and MD5 sums checked
package 'yaml' successfully unpacked and MD5 sums checked
All packages appear to have installed correctly
Using C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/RequireSnapshot/file6df068ad1e70; setting `require = FALSE`
-- Installing from:
  -- Archive: remotes
-- 1 of 1. Estimated time left: ...; est. finish: ...calculating
installing older versions is still experimental and may cause package version conflicts
-- Determining dates on MRAN to get correct versions ... 
Installing package into 'C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/ASEZCK'
(as 'lib' is unspecified)
trying URL 'https://MRAN.revolutionanalytics.com/snapshot/2021-11-29/bin/windows/contrib/4.2/remotes_2.4.1.zip'
Content type 'application/zip' length 398634 bytes (389 KB)
==================================================
downloaded 389 KB

package 'remotes' successfully unpacked and MD5 sums checked
All packages appear to have installed correctly
 to echo the multiple paths in C:/Users/cbarros/AppData/Local/Temp/RtmpQJDSov/working_dir/RtmpyIXl5H/Require/d74oTr7P/packageVersions.txt
Error from cbind(deparse.level, ...) 
Error in data.frame(..., check.names = FALSE) : 
  arguments imply differing number of rows: 419, 424
Calls: test_pkg ... .installed.pkgs -> lapply -> FUN -> cbind -> cbind -> data.frame
Execution halted

1 error ✖ | 0 warnings ✔ | 1 note ✖
Error: R CMD check found ERRORs
Execution halted

Exited with status 1.
```