### PR TITLE
bugfix in `getAvailable`

### DIFF
--- a/R/Require-helpers.R
+++ b/R/Require-helpers.R
@@ -192,7 +192,7 @@ getAvailable <- function(pkgDT, purge = FALSE, repos = getOption("repos"),
         # If package has both a binary and source available on CRAN, there will be 2 entries
         pDT[correctVersionAvail == TRUE, N := .N, by = "packageFullName"]
         # # CRAN before GitHub, if "correctVersionAvail" is TRUE
-        setorderv(pDT, c("hasHEAD", "correctVersionAvail", "repoLocation"), order = c(-1L, 1L, 1L), na.last = TRUE) # put TRUE first
+        setorderv(pDT, c("hasHEAD", "correctVersionAvail", "repoLocation"), order = c(-1L, -1L, 1L), na.last = TRUE) # put TRUE first
         pDT[, keep := min(.I), by = "Package"]
         pDT <- pDT[unique(pDT$keep),]
         set(pDT, NULL, "keep", NULL)


### PR DESCRIPTION
When multiple pkg versions were detected, the lines with correct versions available were being put last.
This fixes the issue with installing `spatspat.utils`, a dependency of `spatstat` that was recently updated. `spatstat` asks for `spatstat.utils` >= 3.0-0.  `spatstat.utils` v3.0-1 is available, but I have a local older version (2.something). The bug was putting my local version first and failing to get the most current one.

