### PR TITLE
robust to NULL osVersion

### DIFF
--- a/R/Require-helpers.R
+++ b/R/Require-helpers.R
@@ -704,7 +704,7 @@ isLinux <- function() {
 }
 
 isUbuntuOrDebian <- function() {
-  grepl("Ubuntu|Debian", utils::osVersion, ignore.case = TRUE)
+  isTRUE(grepl("Ubuntu|Debian", utils::osVersion, ignore.case = TRUE))
 }
 warningCantInstall <- function(pkgs, libPaths = .libPaths()) {
   warning(


### PR DESCRIPTION
`osVersion` can be `NULL` (`?osVersion`). That would break usage of this function in `if()` checks. This `isTRUE()` wrapper is the easiest workaround.