### PR TITLE
Fix inconsistent getOption("Require.usePak") fallback values

### DIFF
--- a/R/Require2.R
+++ b/R/Require2.R
@@ -316,7 +316,7 @@ Require <- function(packages,
 
     basePkgsToLoad <- packages[packages %in% .basePkgs]
 
-    if (getOption("Require.usePak", TRUE)) {
+    if (getOption("Require.usePak", FALSE)) {
       opts <- options(repos = repos); on.exit(options(opts), add = TRUE)
 
       log <- tempfile2(fileext = ".txt")

--- a/R/extract.R
+++ b/R/extract.R
@@ -116,7 +116,7 @@ trimVersionNumber <- function(pkgs) {
     nas <- is.na(pkgs)
     if (any(!nas)) {
       ew <- endsWith(pkgs[!nas], ")")
-      if (getOption("Require.usePak", TRUE))
+      if (getOption("Require.usePak", FALSE))
         ew <- ew | grepl("@", pkgs[!nas])
       if (any(ew)) {
         pkgs[!nas][ew] <- gsub(paste0("\n|\t|", .grepVersionNumber), "", pkgs[!nas][ew])

--- a/R/pkgDep3.R
+++ b/R/pkgDep3.R
@@ -130,7 +130,7 @@ pkgDep <- function(packages,
   }
   if (length(packages)) {
     which <- depsImpsSugsLinksToWhich(depends, imports, suggests, linkingTo, which)
-    if (getOption("Require.usePak", TRUE)) {
+    if (getOption("Require.usePak", FALSE)) {
       if (!requireNamespace("pak")) stop("Please install pak")
       log <- tempfile2(fileext = ".txt")
       withCallingHandlers(


### PR DESCRIPTION
`RequireOptions()` declares `Require.usePak` = FALSE as the package default, but three call sites used `getOption("Require.usePak", TRUE)` as an inline fallback, which would silently activate `pak` if the option was ever unset.

This PR changes all three fallbacks from TRUE to FALSE to be consistent with the declared default:

- [Require2.R]  line 319
- [pkgDep3.R] line 133
- [extract.R] line 119

No behavior change under normal usage (since .onLoad sets the option via `RequireOptions()`), but this prevents unexpected pak activation if the option is reset to NULL.
