### PR TITLE
fix(CRAN): make isBinaryCRANRepo() resilient when "CRAN" name is absent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-05-26
-Version: 2.0.0.9001
+Version: 2.0.0.9002
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# Require 2.0.0.9002 (development version)
+
+* `isBinaryCRANRepo()` no longer errors with "subscript out of bounds"
+  when `getOption("repos")` has no element named "CRAN". This can
+  happen when calling code rebuilds the repos option in a way that
+  drops names, e.g. `unique(c(extraRepo, getOption("repos")))`.
+  The default now resolves CRAN lazily and falls back to `NA` when
+  absent.
+
 # Require 2.0.0.9001 (development version)
 
 * Recover from `cannot be unloaded ... imported by` failure via

--- a/R/Require-helpers.R
+++ b/R/Require-helpers.R
@@ -641,8 +641,16 @@ isBinary <- function(fn, needRepoCheck = TRUE, repos = getOption("repos")) {
   theTest
 }
 
-isBinaryCRANRepo <- function(curCRANRepo = getOption("repos")[["CRAN"]],
+isBinaryCRANRepo <- function(curCRANRepo = NULL,
                              repoToTest = formals(setLinuxBinaryRepo)[["binaryLinux"]]) {
+  if (is.null(curCRANRepo)) {
+    r <- getOption("repos")
+    # `r[["CRAN"]]` throws "subscript out of bounds" on a named character
+    # vector when no element is named "CRAN" -- can happen if a caller has
+    # rebuilt `options("repos")` in a way that drops names (e.g. via
+    # `unique(c(extraRepo, getOption("repos")))`).
+    curCRANRepo <- if ("CRAN" %in% names(r)) r[["CRAN"]] else NA_character_
+  }
   if (isWindows() || isMacOS()) {
     isBin <- grepl("[\\|/])|/bin[\\|/]", curCRANRepo)
   } else {


### PR DESCRIPTION
## Summary
- `isBinaryCRANRepo()`'s default arg `curCRANRepo = getOption("repos")[["CRAN"]]` threw `subscript out of bounds` on a named character vector when no element was named `CRAN`.
- Triggered in caller code that rebuilt `options("repos")` in a way that dropped names, e.g. `unique(c("https://predictiveecology.r-universe.dev", getOption("repos")))`.
- Defaults are now `NULL` and resolved lazily inside the function, falling back to `NA_character_` when no `CRAN` entry exists. Behavior unchanged when `CRAN` is present.
- Version bumped to `2.0.0.9002`; NEWS updated.

## Test plan
- [ ] `R CMD check`
- [ ] `options(repos = unname(c("https://predictiveecology.r-universe.dev", getOption("repos")))); Require::Require("data.table")` no longer errors with `subscript out of bounds`.
- [ ] Default path with a normal `CRAN`-named `options("repos")` still returns the same `isBin` value as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)