### PR TITLE
fix(setup): suppress read.csv warning leak in whIsOfficialCRANrepo() [HIGH PRIORITY]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-05-26
-Version: 2.0.0.9001
+Version: 2.0.0.9002
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# Require 2.0.0.9002 (development version)
+
+* `whIsOfficialCRANrepo()` no longer leaks a "cannot open file"
+  warning when the cached `.mirrors.csv` is absent and the download
+  fallback also fails (offline / fresh cache).
+  `try(read.csv(...), silent = TRUE)` swallows the *error* but
+  `file()` signals the warning first, so it escaped to callers'
+  `withCallingHandlers` (e.g. `SpaDES.project::setupProject`),
+  whose handlers probed the call stack for variables that do not
+  exist on the pak code path -- crashing with
+  `Error in get(obj, envir = env, inherits = FALSE) : object 'pkgDT' not found`.
+  The read is now skipped when the file is absent, and wrapped in
+  `suppressWarnings()` otherwise.
+
 # Require 2.0.0.9001 (development version)
 
 * Recover from `cannot be unloaded ... imported by` failure via

--- a/R/setup.R
+++ b/R/setup.R
@@ -452,10 +452,19 @@ whIsOfficialCRANrepo <- function(currentRepos = getOption("repos"), backupCRAN =
         download.file("https://cran.r-project.org/CRAN_mirrors.csv",
                       destfile = mirrorsLocalFile, quiet = TRUE),
         silent = TRUE))
-    a <- try(read.csv(mirrorsLocalFile), silent = TRUE)
+    ## Even with `try(silent = TRUE)`, `read.csv` on a missing file signals a
+    ## "cannot open file" warning before erroring (via file()). That warning
+    ## escapes `try()` and can be caught by callers' withCallingHandlers (e.g.
+    ## SpaDES.project) that then probe the stack for vars not in our code path.
+    ## Skip the read when the file is absent, and suppress the warning otherwise.
+    a <- if (file.exists(mirrorsLocalFile)) {
+      try(suppressWarnings(read.csv(mirrorsLocalFile)), silent = TRUE)
+    } else {
+      structure("download failed", class = "try-error")
+    }
     if (!is(a, "try-error"))
       break
-    unlink(mirrorsLocalFile)
+    if (file.exists(mirrorsLocalFile)) unlink(mirrorsLocalFile)
     if (attempt == 2) {
       # https://stackoverflow.com/a/76684292/3890027
       enableSSLWorkaround()

--- a/tests/testthat/test-15bugfixes_testthat.R
+++ b/tests/testthat/test-15bugfixes_testthat.R
@@ -929,3 +929,44 @@ test_that("extractMissingSysreqs parses pak's 'Missing N system packages' block"
   expect_identical(Require:::extractMissingSysreqs("nothing relevant"), character(0))
   expect_identical(Require:::extractMissingSysreqs(character(0)), character(0))
 })
+
+test_that("whIsOfficialCRANrepo does not leak 'cannot open file' warning when .mirrors.csv is absent", {
+  # Regression: when the cached .mirrors.csv is absent AND download.file fails
+  # (offline / fresh cache), `try(read.csv(...), silent = TRUE)` swallowed the
+  # error but `file()` signals a "cannot open file" warning before erroring,
+  # which escaped try(). That warning was caught by callers' withCallingHandlers
+  # (e.g. SpaDES.project::setupProject) whose handlers probed the call stack
+  # for `pkgDT` -- a variable that doesn't exist on the pak code path --
+  # crashing with: Error in get(obj, envir = env, inherits = FALSE).
+
+  tmpCache <- tempfile("requireMirrorsTest")
+  dir.create(tmpCache)
+  on.exit(unlink(tmpCache, recursive = TRUE), add = TRUE)
+
+  caught <- character()
+  withr::with_envvar(
+    c(R_REQUIRE_CACHE = tmpCache),
+    {
+      with_mocked_bindings(
+        download.file = function(...) stop("simulated offline"),
+        .package = "Require",
+        {
+          withCallingHandlers(
+            try(Require:::whIsOfficialCRANrepo(
+              currentRepos = c(CRAN = "https://cloud.r-project.org")
+            ), silent = TRUE),
+            warning = function(w) {
+              caught <<- c(caught, conditionMessage(w))
+              invokeRestart("muffleWarning")
+            }
+          )
+        }
+      )
+    }
+  )
+
+  expect_false(
+    any(grepl("cannot open", caught)),
+    info = paste("Leaked warnings:", paste(caught, collapse = "; "))
+  )
+})


### PR DESCRIPTION
## Summary
High-priority bug. `whIsOfficialCRANrepo()` leaked a `"cannot open file"` warning when the cached `.mirrors.csv` is absent and `download.file` also failed (offline / fresh cache).

- `try(read.csv(mirrorsLocalFile), silent = TRUE)` swallowed the *error*, but `file(file, "rt")` signals the warning **before** erroring, so the warning escaped `try()`.
- Caught by `SpaDES.project::setupProject(...)`'s `withCallingHandlers(warning = ...)`, whose handler then probed the call stack for `pkgDT` — a variable that does not exist on the current pak code path — and crashed with:

  ```
  Error in get(obj, envir = env, inherits = FALSE) : object 'pkgDT' not found
  ```

Fix: skip the `read.csv` when the file is absent, and `suppressWarnings()` it when present. Success path unchanged.

## Test plan
- [x] New regression test in `tests/testthat/test-15bugfixes_testthat.R` (`whIsOfficialCRANrepo does not leak 'cannot open file' warning ...`): mocks `download.file` to fail under a tempdir cache and asserts no `"cannot open"` warning escapes. Verified locally — full bugfixes file passes.
- [ ] GHA full matrix passes.
- [ ] Real-world: SpaDES.project workflow against a fresh cache (no `.mirrors.csv`) no longer crashes with `object 'pkgDT' not found`.

## Related
Independent of #153 but surfaced from the same SpaDES.project debugging session. Both PRs bump `DESCRIPTION` to `2.0.0.9002`; whichever merges second will need a trivial bump to `9003`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)