### PR TITLE
ci: drop windows-latest oldrel-3 (R 4.2)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,13 @@ jobs:
           - {os: windows-latest,  r: 'release'}  ## currently 4.5
           - {os: windows-latest,  r: 'oldrel-1'} ## currently 4.4
           - {os: windows-latest,  r: 'oldrel-2'} ## currently 4.3
-          - {os: windows-latest,  r: 'oldrel-3'} ## currently 4.2
+          # windows-latest oldrel-3 (R 4.2) intentionally dropped: pak's
+          # stable channel and CRAN's binary index for R 4.2 on Windows
+          # are now thin enough that dep-install storms routinely hang
+          # past GHA's 6h max-runtime (observed during PR #155). R 4.2
+          # is still covered on Linux by ubuntu-latest oldrel-3 below.
+          # Re-add when there's a Windows R 4.2 setup that resolves
+          # deps in well under an hour.
           - {os: ubuntu-latest,   r: 'devel'}
           # Single matrix entry that opts in to the slow integration tests
           # (5 archived-CRAN install round-trips in test-16 — measured at

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: A single key function, 'Require' that makes rerun-tolerant
 URL: 
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
-Date: 2026-05-27
-Version: 2.0.0.9013
+Date: 2026-05-28
+Version: 2.0.0.9014
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",


### PR DESCRIPTION
## Why

Recent PR cycles (notably #155) repeatedly hung windows-oldrel-3 past GHA's 6h max-runtime, then got auto-marked \`cancelled\` when later pushes hit concurrency-cancel. On the development branch the same runner finishes in ~17 min, so it isn't broken-broken -- but pak's stable channel + CRAN's R 4.2 Windows binary index have thinned enough that one bad combination wedges the runner. The cost (perpetual yellow/red on the PR check matrix, occasional 6h cap waste) outweighs the marginal coverage benefit.

## What

Drop \`{os: windows-latest, r: 'oldrel-3'}\` from \`.github/workflows/R-CMD-check.yaml\` matrix. R 4.2 stays covered on Linux via \`ubuntu-latest oldrel-3\`. Inline comment in the workflow explains the reason and conditions for re-adding.

\`DESCRIPTION\` bumped to \`2.0.0.9014\` so the build identifier moves.

## Test plan
- [ ] R-CMD-check matrix runs with 10 jobs (down from 11) and is fully green.
- [ ] R 4.2 still exercised on ubuntu-latest oldrel-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)