### PR TITLE
feat(pak): cache per-package dependency resolution (in-memory + disk)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-05-28
-Version: 2.0.0.9019
+Version: 2.0.0.9020
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# Require 2.0.0.9020 (development version)
+
+* pak per-package dependency resolution is now cached per ref (two tiers:
+  in-memory for the session + disk across restarts), via the new
+  `pakPkgDepsCached()` helper. Previously only the *whole* requested package
+  set was cached (`pakDepsResolve()`), so changing a single ref in `reqdPkgs`
+  invalidated the key and forced every ref to be re-resolved online when pak's
+  batch resolution failed and the slow per-package fallback ran. Now a repeat
+  call with only a few changed refs re-resolves online just those; unchanged
+  refs come from cache. This restores the pre-pak behaviour where `pkgDep()`
+  was memoised per package. A `verbose >= 1` note reports how many refs were
+  served from cache. TTL/offline/`purge` semantics match `pakDepsResolve()`
+  (`options(Require.pak.depCacheTTL=)`, default 24 h).
+
 # Require 2.0.0.9019 (development version)
 
 * When `confirmEqualsDontViolateInequalitiesThenTrim()` rejects an

--- a/R/pak.R
+++ b/R/pak.R
@@ -1776,6 +1776,70 @@ pakDepsCacheDir <- function() {
   file.path(cacheDir(), "pak", "pkg_deps")
 }
 
+## Per-package (single-ref) variant of the resolver disk cache. Kept in its own
+## subdir so single-ref entries don't intermingle with the whole-set entries.
+pakDepsCacheDirOne <- function() {
+  file.path(cacheDir(), "pak", "pkg_deps_one")
+}
+
+# ---------------------------------------------------------------------------
+# pakPkgDepsCached() -- per-package cached wrapper around pak::pkg_deps().
+#
+# The whole-set resolver cache in pakDepsResolve() is all-or-nothing: changing
+# ONE ref in the requested set changes the key and forces a full re-resolution.
+# The per-package fallback below resolves each ref independently, so cache each
+# ref's pak_result independently too. A repeat call where only a few refs
+# changed then re-resolves online only the changed refs; the unchanged refs are
+# served from memory (this session) or disk (across restarts) -- restoring the
+# pre-pak behaviour where pkgDep() was memoised per package.
+#
+# Key = md5(query, wh, repos, srcOnly) via pakDepsCacheKey(). The query already
+# carries the installed-version pin (pinInstalledForPak) and any == -> @version
+# conversion, so the key is self-invalidating when that ref's installed version
+# changes. TTL + offline semantics mirror pakDepsResolve().
+# ---------------------------------------------------------------------------
+pakPkgDepsCached <- function(query, wh, repos, verbose, purge,
+                             type = getOption("pkgType")) {
+  key       <- pakDepsCacheKey(query, wh, repos, type = type)
+  envKey    <- paste0("pakDeps1_", key)
+  cacheDir  <- pakDepsCacheDirOne()
+  cacheFile <- file.path(cacheDir, paste0(key, ".rds"))
+  ttl       <- getOption("Require.pak.depCacheTTL", .pakDepsCacheTTL)
+  offline   <- isTRUE(getOption("Require.offlineMode"))
+
+  if (!isTRUE(purge)) {
+    cached <- get0(envKey, envir = pakEnv(), inherits = FALSE)
+    if (!is.null(cached)) {
+      assign(".pakPkgDepsHits", get0(".pakPkgDepsHits", envir = pakEnv(),
+             ifnotfound = 0L, inherits = FALSE) + 1L, envir = pakEnv())
+      return(cached)
+    }
+    if (file.exists(cacheFile)) {
+      age <- as.numeric(difftime(Sys.time(), file.mtime(cacheFile), units = "secs"))
+      if (offline || age < ttl) {
+        cached <- tryCatch(readRDS(cacheFile), error = function(e) NULL)
+        if (!is.null(cached)) {
+          assign(envKey, cached, envir = pakEnv())   # promote to memory tier
+          assign(".pakPkgDepsHits", get0(".pakPkgDepsHits", envir = pakEnv(),
+                 ifnotfound = 0L, inherits = FALSE) + 1L, envir = pakEnv())
+          return(cached)
+        }
+      }
+    }
+  }
+
+  result <- tryCatch(pakCall(pak::pkg_deps(query, dependencies = wh), verbose),
+                     error = function(e) NULL)
+  if (!is.null(result)) {
+    assign(envKey, result, envir = pakEnv())
+    tryCatch({
+      dir.create(cacheDir, recursive = TRUE, showWarnings = FALSE)
+      saveRDS(result, cacheFile)
+    }, error = function(e) NULL)   # non-fatal if disk write fails
+  }
+  result
+}
+
 pakDepsResolve <- function(pkgsForPak, wh, repos, verbose, purge, userPkgs = NULL,
                            type = getOption("pkgType")) {
 
@@ -1989,16 +2053,25 @@ pakDepsResolve <- function(pkgsForPak, wh, repos, verbose, purge, userPkgs = NUL
                    verbose = verbose, verboseLevel = 1)
     archiveRefs <- grep("^url::", pkgsForPak, value = TRUE)
     nonArchivePkgs <- pkgsForPak[!grepl("^url::", pkgsForPak)]
+    # Reset the per-package cache-hit counter so the summary below reports only
+    # this loop's hits. pakPkgDepsCached() caches each ref independently, so a
+    # repeat call with only a few changed refs re-resolves online just those.
+    assign(".pakPkgDepsHits", 0L, envir = pakEnv())
     per_pkg_results <- lapply(nonArchivePkgs, function(pkg) {
       # First try with archive refs (for packages with archived transitive deps).
       # If that fails (e.g., archive refs introduce new CRAN/GitHub conflicts), retry
       # without archive refs -- it's better to get a partial dep tree than nothing.
       query <- if (length(archiveRefs)) unique(c(pkg, archiveRefs)) else pkg
-      result <- tryCatch(pakCall(pak::pkg_deps(query, dependencies = wh), verbose), error = function(e) NULL)
+      result <- pakPkgDepsCached(query, wh, repos, verbose, purge, type = type)
       if (is.null(result) && length(archiveRefs))
-        result <- tryCatch(pakCall(pak::pkg_deps(pkg, dependencies = wh), verbose), error = function(e) NULL)
+        result <- pakPkgDepsCached(pkg, wh, repos, verbose, purge, type = type)
       result
     })
+    nHits <- get0(".pakPkgDepsHits", envir = pakEnv(), ifnotfound = 0L, inherits = FALSE)
+    if (nHits > 0L)
+      messageVerbose("Require/pak per-package resolution: ", nHits, " of ",
+                     length(nonArchivePkgs), " refs served from cache",
+                     verbose = verbose, verboseLevel = 1)
     per_pkg_results <- per_pkg_results[!sapply(per_pkg_results, is.null)]
     if (length(per_pkg_results)) {
       pak_result <- tryCatch(

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -219,6 +219,91 @@ test_that("pakDepsResolve disk cache hit emits message at verbose = 1", {
 })
 
 # ---------------------------------------------------------------------------
+# 5b. pakPkgDepsCached: per-package (single-ref) cache. The per-package fallback
+# loop caches each ref independently so a repeat call with only a few changed
+# refs re-resolves online just those. Both cache-hit tests short-circuit before
+# any pak::pkg_deps() call, so they need no network.
+# ---------------------------------------------------------------------------
+
+test_that("pakPkgDepsCached returns from in-memory cache without network", {
+  skip_if_not_installed("pak")
+
+  query <- "any::data.table"
+  wh    <- c("Imports", "Depends", "LinkingTo")
+  repos <- c(CRAN = "https://cloud.r-project.org")
+
+  key    <- Require:::pakDepsCacheKey(query, wh, repos)
+  envKey <- paste0("pakDeps1_", key)
+  fake   <- data.frame(package = "data.table", version = "1.15.0",
+                       ref = "data.table", direct = TRUE,
+                       stringsAsFactors = FALSE)
+  assign(envKey, fake, envir = Require:::pakEnv())
+  on.exit(rm(list = envKey, envir = Require:::pakEnv()), add = TRUE)
+
+  assign(".pakPkgDepsHits", 0L, envir = Require:::pakEnv())
+  res <- Require:::pakPkgDepsCached(query, wh, repos, verbose = 0, purge = FALSE)
+  testthat::expect_identical(res, fake)
+  testthat::expect_equal(
+    get0(".pakPkgDepsHits", envir = Require:::pakEnv(), ifnotfound = 0L), 1L)
+})
+
+test_that("pakPkgDepsCached returns from disk cache and promotes to memory", {
+  skip_if_not_installed("pak")
+
+  query     <- "any::digest"
+  wh        <- c("Imports", "Depends", "LinkingTo")
+  repos     <- c(CRAN = "https://cloud.r-project.org")
+  key       <- Require:::pakDepsCacheKey(query, wh, repos)
+  envKey    <- paste0("pakDeps1_", key)
+  cacheDir  <- Require:::pakDepsCacheDirOne()
+  cacheFile <- file.path(cacheDir, paste0(key, ".rds"))
+  fake      <- data.frame(package = "digest", version = "0.6.35",
+                          ref = "digest", direct = TRUE,
+                          stringsAsFactors = FALSE)
+  dir.create(cacheDir, recursive = TRUE, showWarnings = FALSE)
+  saveRDS(fake, cacheFile)
+  on.exit(unlink(cacheFile), add = TRUE)
+
+  # No in-memory entry, so the disk path is exercised.
+  if (exists(envKey, envir = Require:::pakEnv(), inherits = FALSE))
+    rm(list = envKey, envir = Require:::pakEnv())
+  on.exit(if (exists(envKey, envir = Require:::pakEnv(), inherits = FALSE))
+            rm(list = envKey, envir = Require:::pakEnv()), add = TRUE)
+
+  res <- Require:::pakPkgDepsCached(query, wh, repos, verbose = 0, purge = FALSE)
+  testthat::expect_equal(res, fake)
+  # Promoted to the in-memory tier for subsequent same-session calls.
+  testthat::expect_true(exists(envKey, envir = Require:::pakEnv(), inherits = FALSE))
+})
+
+test_that("pakPkgDepsCached bypasses cache when purge = TRUE", {
+  skip_if_not_installed("pak")
+
+  query  <- "any::data.table"
+  wh     <- c("Imports", "Depends", "LinkingTo")
+  repos  <- c(CRAN = "https://cloud.r-project.org")
+  key    <- Require:::pakDepsCacheKey(query, wh, repos)
+  envKey <- paste0("pakDeps1_", key)
+
+  # Inject a sentinel; with purge = TRUE it must NOT be returned (the helper
+  # would instead attempt a real resolution, which we don't run here).
+  sentinel <- data.frame(package = "SENTINEL", stringsAsFactors = FALSE)
+  assign(envKey, sentinel, envir = Require:::pakEnv())
+  on.exit(if (exists(envKey, envir = Require:::pakEnv(), inherits = FALSE))
+            rm(list = envKey, envir = Require:::pakEnv()), add = TRUE)
+
+  assign(".pakPkgDepsHits", 0L, envir = Require:::pakEnv())
+  # We only assert the cache was NOT consulted (hit counter stays 0); the
+  # subsequent network resolution is allowed to fail/return anything.
+  suppressWarnings(suppressMessages(
+    try(Require:::pakPkgDepsCached(query, wh, repos, verbose = 0, purge = TRUE),
+        silent = TRUE)
+  ))
+  testthat::expect_equal(
+    get0(".pakPkgDepsHits", envir = Require:::pakEnv(), ifnotfound = 0L), 0L)
+})
+
+# ---------------------------------------------------------------------------
 # 6. recordLoadOrder: GitHub ref replaced by CRAN version-spec ref
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

When `options(Require.usePak = TRUE)`, dependency resolution goes through `pakDepsResolve()`, which caches the result in two tiers (in-memory + disk). **But the cache is keyed on the *whole* requested package set.** In real-world use, pak's *batch* `pkg_deps()` usually fails on cross-package conflicts, so Require drops to the slow **per-package fallback** (one `pak::pkg_deps()` callr subprocess per top-level ref — the ~4 min the user sees).

Because the cache key covers the entire set, changing a single ref in `reqdPkgs` invalidates it and re-resolves **every** ref online. Pre-pak Require memoised `pkgDep()` *per package*, so "repeat call with few/no changes" was fast — this PR restores that.

## Change

New `pakPkgDepsCached()` (R/pak.R): a light wrapper around `pak::pkg_deps()` that caches **each ref independently** in both tiers:
- memory: `pakEnv()` key `pakDeps1_<md5>`
- disk: `<cacheDir>/pak/pkg_deps_one/<md5>.rds`

It reuses the existing `pakDepsCacheKey()` (the query already carries the installed-version pin, so it self-invalidates), and matches `pakDepsResolve()`'s TTL / offline / `purge` semantics (`options(Require.pak.depCacheTTL=)`, default 24 h). The per-package fallback loop now calls it and reports `"N of M refs served from cache"` at `verbose >= 1`.

Net effect: a rerun with **a few changed refs** re-resolves online only the changed refs; unchanged ones come from memory (same session) or disk (after restart).

### Caveat / not in scope
The 5 whole-set batch retries still run before the per-package fallback on a cache miss — only the per-package leg is now individually cached. The earlier `pak/pkgDT` converted-plan cache is already gone from current code (unrelated).

## Tests
`tests/testthat/test-17usePak.R` adds 3 `pakPkgDepsCached` tests (memory hit, disk hit + promotion, `purge=TRUE` bypass) — hit-paths need no network. All pass locally.

Version bump `2.0.0.9019` → `2.0.0.9020`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)