### PR TITLE
fix(tests): suppress stale-DESCRIPTION warning leak in useLoadedIfSufficient

### DIFF
--- a/R/Require-helpers.R
+++ b/R/Require-helpers.R
@@ -473,8 +473,16 @@ useLoadedIfSufficient <- function(pkgDT,
       ok <- isTRUE(compareVersion2(loadedVer, vSpec, ineq))
       if (!ok) next
     }
-    lp <- tryCatch(dirname(system.file(package = pkg)),
-                   error = function(e) NA_character_)
+    # suppressWarnings: this is a best-effort "where does pkg live" probe. When a
+    # namespace stays loaded after its files were removed (the very case the
+    # hasDescOnDisk check below handles), system.file()/find.package() walk the
+    # libPaths and read.dcf() the stale DESCRIPTION path, emitting "cannot open
+    # compressed file '<lib>/<pkg>/DESCRIPTION'". (Pronounced under devtools::test,
+    # where pkgload shims system.file().) tryCatch only traps errors, so that
+    # warning leaked out and tripped tests asserting a clean warning set. The
+    # missing-files case is already handled below; the warning is pure noise here.
+    lp <- suppressWarnings(tryCatch(dirname(system.file(package = pkg)),
+                                    error = function(e) NA_character_))
     if (!nzchar(lp)) lp <- NA_character_
     if (!is.na(lp) && !normPath(lp) %in% effectiveLibPaths) next
     ## Disk-presence check: a namespace can stay loaded after its files are


### PR DESCRIPTION
Round 2 of local `devtools::test()` failures (the `skip_on_ci()`-gated tests that only run locally). A full local run on the merged `development` showed **`[ FAIL 7 | WARN 2 | SKIP 3 | PASS 641 ]`**, from two distinct root causes.

## Issue A — Require warning leak (5 failures) — FIXED here

`useLoadedIfSufficient()` probes `dirname(system.file(package = pkg))` to find where a loaded package lives. When a namespace stays loaded after its files were removed (e.g. `remove.packages()` mid-session — exactly the case the `hasDescOnDisk` check right below it handles), `system.file()` / `find.package()` walk the libPaths and `read.dcf()` the stale path, emitting:

```
cannot open compressed file '<lib>/<pkg>/DESCRIPTION', probable reason 'No such file or directory'
```

This is pronounced under `devtools::test()`, where **pkgload shims `system.file()`**. The `tryCatch` there only trapped *errors*, so the warning leaked out and tripped tests that assert a clean warning set:

- `test-05packagesLong:144` (×2), `:157` — via `testWarnsInUsePleaseChange()`
- `test-10DifferentPkgs:40` — same
- `test-12offlineMode:52` — the offline `warns2` empty-set check

Backtrace confirming the source:
```
useLoadedIfSufficient() [Require-helpers.R:476]
  -> tryCatch(dirname(system.file(package = pkg)), error=...)
    -> system.file (pkgload shim) -> find.package -> read.dcf(file.path(p,"DESCRIPTION"))
```

Fix: wrap the probe in `suppressWarnings()`. The missing-files case is already handled immediately below (`hasDescOnDisk` -> re-route to install), so the warning is pure noise.

## Issue B — pak build-worker crash (2 failures) — NOT a Require bug

`test-01packages:293/302` (the issue-87 SHA-downgrade regression test) expect `reproducible` to downgrade to `2.0.2.9001` from a pinned GitHub commit. The downgrade *logic* worked (`pak` selected `3.1.1.9035 -> 2.0.2.9001 (GitHub: 51ecfd2)`), but the install died inside pak's *packaging* step:

```
Caused by error in `zip_data$unzip_class %||% R6::R6Class("unzip_process", inherit = processx::process, ...`
```

This was one of **29 pak build-worker crashes** (`stop_task_build` / `unzip_class` / processx) in the run — a stability problem with the installed `pak 0.9.5.9000` **dev** build, not Require logic. Per our "light pak wrappers" principle, no Require workaround was added.

**Action taken:** updated pak `0.9.5.9000` (dev) -> `0.9.5` (stable) locally and kicked off a fresh full local run to confirm whether stable pak clears test-01. Result pending — will update this PR.

## Verification

- Issue A fix is proven by the backtrace; CI here exercises the non-`skip_on_ci` tests.
- A full local `devtools::test()` (the only thing that runs the `skip_on_ci` set) is running on this branch with the updated pak. Expected: `FAIL 7 -> 2` (Issue A cleared), and `-> 0` if stable pak also fixes Issue B.

Note: `development` already carries the version bump to `2.0.0.9021` from #159; no further bump here yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)