### PR TITLE
fix(pak): don't double-@ a GitHub @sha ref carrying a (== version) pin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-02
-Version: 2.0.0.9021
+Version: 2.0.0.9022
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# Require 2.0.0.9022 (development version)
+
+* Fixed `Install("owner/repo@<sha> (== X)")` (a GitHub ref pinned by commit
+  *and* an exact version) silently no-op'ing when a different version was
+  already installed, then warning "pak resolved X but only Y is available as a
+  binary". The install path's `equalsToAt()` appended `@X` to the already-`@sha`
+  -pinned ref, producing a malformed `owner/repo@sha@X` ref pak could not
+  install. `equalsToAt()`/`lessThanToAt()` now skip refs that already carry an
+  `@` pin; the version parenthetical is stripped by `trimVersionNumber()` and
+  Require's post-install check verifies the version. The pinned commit now
+  installs (downgrading if needed) as expected.
+
 # Require 2.0.0.9020 (development version)
 
 * pak per-package dependency resolution is now cached per ref (two tiers:

--- a/R/pak.R
+++ b/R/pak.R
@@ -3157,11 +3157,21 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
   # Strip HEAD flags (Require already decided to install HEAD packages)
   pkgs <- HEADtoNone(pkgs)
 
-  # == version -> @version (exact pin for pak)
-  pkgs <- equalsToAt(pkgs)
-
+  # Translate == / <= constraints to pak's @version exact-pin form -- but skip
+  # refs that ALREADY carry an `@` pin (i.e. a GitHub `owner/repo@sha`/`@branch`
+  # ref). For those, appending @<version> here produces a malformed
+  # `owner/repo@sha@version` ref that pak cannot install: it silently keeps the
+  # installed version (a no-op), and Require then warns "pak resolved X but only
+  # Y is available as a binary". The version parenthetical on an already-pinned
+  # GitHub ref is a package-version constraint (not a git ref); it is stripped by
+  # trimVersionNumber() below, and Require's post-install check verifies the
+  # installed version. (A GitHub ref WITHOUT an `@` still goes through
+  # equalsToAt, preserving the existing `owner/repo (== X)` -> `owner/repo@X`
+  # behaviour.)
+  whUnpinned <- !grepl("@", pkgs)
+  pkgs[whUnpinned] <- equalsToAt(pkgs[whUnpinned])    # == version -> @version (exact pin)
   # <= version -> find highest satisfying version via pak::pkg_history() -> @version
-  pkgs <- lessThanToAt(pkgs)
+  pkgs[whUnpinned] <- lessThanToAt(pkgs[whUnpinned])
 
   # >= version: strip the constraint. Since Require already checked that the installed
   # version does NOT satisfy >=, installing the latest will always satisfy it.

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1570,3 +1570,35 @@ test_that("pinInstalledForPak skips user-version-constrained packages", {
   testthat::expect_true(grepl("^data.table@", out[2]),
     info = "bare user packages with no constraint must be pinned to installed version to keep deps stable")
 })
+
+# ---------------------------------------------------------------------------
+# Regression: a GitHub ref pinned by BOTH @sha and (== version) must not be
+# turned into a malformed double-@ ref `owner/repo@sha@version` by the install
+# path. equalsToAt() used to run on the whole ref, appending @version to the
+# already-@sha-pinned ref; pak then could not install it and silently kept the
+# installed version, after which Require warned "pak resolved X but only Y is
+# available as a binary". The install path now skips equalsToAt()/lessThanToAt()
+# for refs that already carry an `@` pin. (R/pak.R, pakInstallFiltered ~L3160.)
+# ---------------------------------------------------------------------------
+test_that("GitHub @sha + (== version) ref is not double-@'d by the install path", {
+  ref <- "PredictiveEcology/reproducible@63cf18a80efa5dcf40957d6f207fce55fa0fdc19 (== 3.1.1.9036)"
+  # Reproduce the pakInstallFiltered transform sequence that builds the pak ref.
+  pkgs <- Require:::HEADtoNone(ref)
+  whUnpinned <- !grepl("@", pkgs)
+  pkgs[whUnpinned] <- Require:::equalsToAt(pkgs[whUnpinned])
+  whGH <- Require:::isGH(pkgs)
+  if (any(whGH)) pkgs[whGH] <- Require:::trimVersionNumber(pkgs[whGH])
+  testthat::expect_equal(
+    pkgs, "PredictiveEcology/reproducible@63cf18a80efa5dcf40957d6f207fce55fa0fdc19")
+  testthat::expect_equal(
+    lengths(regmatches(pkgs, gregexpr("@", pkgs, fixed = TRUE))), 1L,
+    info = "ref must carry exactly one @ (the sha), never @sha@version")
+
+  # Non-GitHub (== version) refs still get pak's @version exact pin.
+  testthat::expect_equal(Require:::equalsToAt("qs (== 0.27.3)"), "qs@0.27.3")
+  # A GitHub ref WITHOUT an @ still gets the @version form (unchanged behaviour).
+  gh <- "owner/repo (== 1.2.3)"
+  whU <- !grepl("@", gh)
+  gh[whU] <- Require:::equalsToAt(gh[whU])
+  testthat::expect_equal(gh, "owner/repo@1.2.3")
+})


### PR DESCRIPTION
## Symptom

```r
Require::Install("PredictiveEcology/reproducible@63cf18a80efa5dcf40957d6f207fce55fa0fdc19 (==3.1.1.9036)")
#> could not be installed: reproducible == 3.1.1.9036; pak resolved 3.1.1.9036
#> but only 3.1.1.9043 is available as a binary on this platform -- install from
#> source or wait for the binary to be built.
```

A GitHub ref pinned by **both** a commit SHA and an exact `(== version)` failed to install (no-op) whenever a *different* version was already installed, and produced a misleading "available as a binary" warning. It should just install the pinned commit (which is that version).

## Root cause

The **install** path (`pakInstallFiltered`, `R/pak.R` ~L3160) ran `equalsToAt()` on the whole ref, converting the trailing `(==3.1.1.9036)` into `@3.1.1.9036` and appending it to the already-`@sha`-pinned ref:

```
PredictiveEcology/reproducible@63cf18a80efa...@3.1.1.9036   ← malformed double-@
```

pak can't install a double-`@` ref, so it kept the installed version (a no-op, "took 1.4s"). Require's post-install check then hit the `pakResolvedNewer` branch (pak resolved 3.1.1.9036, disk still had the newer version) and emitted the binary-lag warning — which is wrong here (the requested version is *older*, not a missing binary).

The **resolve** path was fine because it strips the version spec (`trimVersionNumber`) before `equalsToAt`.

## Fix

Skip `equalsToAt()` / `lessThanToAt()` for refs that already carry an `@` pin (GitHub `@sha`/`@branch`). The version parenthetical on such a ref is a package-version constraint, not a git ref; it's stripped by the existing `trimVersionNumber()` for GitHub refs just below, and Require's post-install check verifies the installed version. A GitHub ref **without** an `@` still goes through `equalsToAt` (`owner/repo (== X)` → `owner/repo@X`), so no behaviour change there. Mirrors the `notGH` guard already used on the resolve and offline paths.

Note: `pakPkgSetup` has the same unguarded `equalsToAt`, but its only caller (`pakRequire`) is dead code, so it's not in the live path and is left untouched.

## Verification

End-to-end, with `reproducible 3.1.1.9039` pre-installed:

```
→ Will update 1 package.
+ reproducible 3.1.1.9039 → 3.1.1.9036 [bld][cmp] (GitHub: 63cf18a)
✔ Installed reproducible 3.1.1.9036 (github::PredictiveEcology/reproducible@63cf18a)
RESULT: reproducible now 3.1.1.9036  |  warnings: (none)
```

Plus a fast, network-free regression test in `test-17usePak.R` (`GitHub @sha + (== version) ref is not double-@'d ...`) asserting the install-path transform yields a single-`@` ref, while CRAN `(==)` and bare-GitHub `(==)` refs are unchanged.

Version bump `2.0.0.9021` → `2.0.0.9022`.

> Heads-up: open PR #162 also bumps to `9022`; whichever merges second will need a trivial DESCRIPTION/NEWS bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)