### PR TITLE
feat(pak): treat a pinned GitHub @sha as an exact-version pin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-02
-Version: 2.0.0.9022
+Version: 2.0.0.9023
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# Require 2.0.0.9023 (development version)
+
+* A pinned GitHub commit (`Install("owner/repo@<sha>")`) is now treated as an
+  exact-version pin under pak: it installs that exact commit even when a
+  *different* version is already installed (previously a bare `@sha` was a no-op
+  whenever any version was installed, because the pak path is version-driven).
+  Implemented by attaching `(== <version pak resolves for that commit>)` to the
+  ref, so the commit's version drives the install decision; an equal installed
+  version is treated as satisfied (a same-version, different-commit case is not
+  distinguished -- dev versions bump per commit). Only explicit commit SHAs
+  qualify (`isExplicitShaPin()`); branch refs, `(HEAD)` refs, and refs already
+  carrying a version spec are unaffected.
+
 # Require 2.0.0.9022 (development version)
 
 * Fixed `Install("owner/repo@<sha> (== X)")` (a GitHub ref pinned by commit

--- a/R/pak.R
+++ b/R/pak.R
@@ -841,6 +841,20 @@ equalsToAt <- function(pkgs) {
   gsub(" {0,3}\\(== {0,4}(.+)\\)", "@\\1", pkgs)
 }
 
+# TRUE for a GitHub ref pinned to an explicit commit SHA (`owner/repo@<sha>`)
+# that the user has NOT already version-constrained or HEAD-flagged. Such a ref
+# means "exactly this commit", so Require treats it as an exact-version pin (see
+# pakDepsToPkgDT step 4b). Branch refs (`owner/repo@development`) are excluded --
+# they track the branch via the HEAD machinery -- as are `(HEAD)`-flagged refs
+# and refs already carrying a `(==/>=/<= ...)` spec. SHA detection: the whole
+# post-`@` token (after stripping any version spec) is 7-40 hex chars.
+isExplicitShaPin <- function(refs) {
+  isGH(refs) &
+    grepl("@[0-9a-fA-F]{7,40}$", trimVersionNumber(refs)) &
+    !grepl("\\(HEAD\\)", refs) &
+    !grepl("\\([[:space:]]*[<>=]", refs)
+}
+
 # Reduce a vector of pak refs to the bare package names that line up with
 # rownames(installed.packages()). Three things to strip:
 #   * "any::"  prefix on plain CRAN refs   (any::cli           -> cli)
@@ -2396,6 +2410,28 @@ pakDepsToPkgDT <- function(packages, which, libPaths, standAlone, verbose,
       matchIdx <- which(extractPkgName(user_pkgFN) == archivePkgNamesFromPak[.i])
       if (length(matchIdx))
         user_pkgFN[matchIdx] <- archiveRefsInPkgsForPak[.i]
+    }
+  }
+
+  # 4b. Treat a pinned GitHub commit (@<sha>) as an exact-version pin.
+  # The pak path is version-driven: whichToInstall only forces an install when a
+  # version constraint is violated, so a *bare* `owner/repo@<sha>` ref is a no-op
+  # whenever any version is already installed -- even though the user asked for
+  # that exact commit. Attach `(== <version pak resolved for that commit>)` so the
+  # commit's version drives the decision: install when the installed version
+  # differs, treat an equal installed version as satisfied (a same-version,
+  # different-commit case is not distinguished -- dev versions bump per commit).
+  # Only explicit commit SHAs qualify; branch refs (which track the branch via
+  # HEAD), `(HEAD)`-flagged refs, and refs the user already version-constrained
+  # are left untouched. Combined with the @sha + (== X) install-path fix, the
+  # implicit `(== X)` resolves and installs cleanly (no malformed @sha@X ref).
+  if (NROW(pak_result) && !is.null(pak_result$version) && !is.null(pak_result$package)) {
+    verMapSha <- setNames(as.character(pak_result$version), pak_result$package)
+    isShaPinned <- isExplicitShaPin(user_pkgFN)
+    for (.j in which(isShaPinned)) {
+      v <- verMapSha[extractPkgName(user_pkgFN[.j])]
+      if (!is.na(v) && nzchar(v))
+        user_pkgFN[.j] <- paste0(user_pkgFN[.j], " (== ", v, ")")
     }
   }
 

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1602,3 +1602,27 @@ test_that("GitHub @sha + (== version) ref is not double-@'d by the install path"
   gh[whU] <- Require:::equalsToAt(gh[whU])
   testthat::expect_equal(gh, "owner/repo@1.2.3")
 })
+
+# ---------------------------------------------------------------------------
+# A pinned GitHub commit (`owner/repo@<sha>`) is treated as an exact-version pin
+# under pak: pakDepsToPkgDT (step 4b) attaches `(== <pak-resolved-version>)` so
+# the commit's version drives whichToInstall (install when the installed version
+# differs; equal version is satisfied). isExplicitShaPin() decides which refs
+# qualify. Branch refs, (HEAD) refs, already-constrained refs, and non-GitHub
+# refs must NOT qualify.
+# ---------------------------------------------------------------------------
+test_that("isExplicitShaPin qualifies only bare GitHub @sha refs", {
+  sha <- "63cf18a80efa5dcf40957d6f207fce55fa0fdc19"
+  qualifies <- Require:::isExplicitShaPin(c(
+    paste0("PredictiveEcology/reproducible@", sha),                 # 1 bare sha   -> TRUE
+    paste0("PredictiveEcology/reproducible@", sha, " (== 3.1.1.9036)"), # 2 == set -> FALSE
+    paste0("PredictiveEcology/reproducible@", sha, " (HEAD)"),      # 3 HEAD       -> FALSE
+    "PredictiveEcology/reproducible@development",                   # 4 branch     -> FALSE
+    "PredictiveEcology/reproducible@63cf18a8",                      # 5 abbrev sha -> TRUE
+    "PredictiveEcology/reproducible",                              # 6 no @       -> FALSE
+    "reproducible (>= 2.0.0)",                                     # 7 CRAN spec  -> FALSE
+    "qs"                                                          # 8 plain      -> FALSE
+  ))
+  testthat::expect_equal(qualifies,
+                         c(TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE))
+})


### PR DESCRIPTION
> **Stacks on #163.** Until #163 merges, this PR's diff includes #163's commit (`fix(pak): don't double-@ ...`). Review the top commit (`feat(pak): treat a pinned GitHub @sha ...`) here; merge #163 first, then this rebases cleanly.

## Motivation

Follow-up to the discussion on #163. Under `usePak` the install decision is **version-driven** — `whichToInstall` only forces an install when a version constraint is violated. So a bare pinned commit was a **no-op whenever any version was already installed**:

```r
# reproducible 3.1.1.9039 already installed
Require::Install("PredictiveEcology/reproducible@63cf18a80efa...")  # no (== X)
#> No packages to install/update      (stays 3.1.1.9039)
```

even though the user pinned that exact commit. The SHA-vs-installed-SHA comparison that *would* force it lives only in the non-pak `downloadGitHub` path (`Require2.R:1353`), and pak-built packages don't even record a `RemoteSha` to compare against. As discussed, **a specific SHA should be equivalent to `==`** — and it fits Require's reproducibility philosophy.

## Change

`pakDepsToPkgDT` (new step 4b) attaches `(== <version pak resolved for that commit>)` to a pinned-commit ref, so the commit's version drives `whichToInstall`:
- installed version **differs** → install that commit;
- installed version **equal** → satisfied, no reinstall (a same-version, different-commit case is not distinguished — dev versions bump per commit, per the design decision).

Qualification is decided by a small testable helper `isExplicitShaPin()`: only explicit commit SHAs (`owner/repo@<7-40 hex>`) qualify. **Branch refs** (`@development`, which track the branch via HEAD), **`(HEAD)`-flagged** refs, **already-version-constrained** refs, and non-GitHub refs are all left untouched.

This relies on #163 — the injected `(== X)` on an `@sha` ref would otherwise hit the malformed `@sha@version` bug.

## Verification

End-to-end, with `reproducible 3.1.1.9039` pre-installed:
```
→ Will update 1 package.
+ reproducible 3.1.1.9039 → 3.1.1.9036 [bld][cmp] (GitHub: 63cf18a)
✔ Installed reproducible 3.1.1.9036 (github::PredictiveEcology/reproducible@63cf18a)
RESULT: reproducible now 3.1.1.9036  |  warnings: (none)
```

Plus a fast, network-free regression test (`isExplicitShaPin qualifies only bare GitHub @sha refs`) covering bare sha / abbrev sha (qualify) vs `==`-set / `(HEAD)` / branch / no-`@` / CRAN-spec / plain (don't).

Version bump `2.0.0.9022` → `2.0.0.9023`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)