### PR TITLE
fix(pak): keep transitive deps of cascade-casualty CRAN packages (e.g. googledrive→gargle)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: A single key function, 'Require' that makes rerun-tolerant
 URL: 
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
-Date: 2026-06-02
-Version: 2.0.0.9022
+Date: 2026-06-06
+Version: 2.0.0.9023
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,25 @@
-# Require 2.0.0.9022 (development version)
+# Require 2.0.0.9023 (development version)
+
+* Fix: a user-requested CRAN package could be installed *without its
+  dependencies* when pak's batch dependency solve was unsolvable. When a few
+  GitHub `Remotes` refs genuinely conflict (e.g. `quickPlot@development` ->
+  `tidyverse/ggplot2` vs a pinned `ggplot2`), pak's error reports many innocent
+  CRAN packages as `"X: dependency conflict"`. `pakDepsResolve()` strips those
+  CRAN refs from `pkgsForPak` to coax the batch solver, but the per-package
+  fallback then resolved only the *stripped* set -- so a stripped top-level
+  package (e.g. `googledrive`) still installed via `user_pkgFN` while its
+  transitive deps (e.g. `gargle`) were never resolved, leaving a broken
+  namespace (`loadNamespace("googledrive")` -> "there is no package called
+  'gargle'"). Two complementary fixes:
+    - `pakDepsResolve()`'s per-package fallback now resolves the **original,
+      unstripped** ref set (in isolation there are no cross-package conflicts,
+      so cascade casualties keep their own dependency subtrees).
+    - `pakDepsToPkgDT()` adds a closure guard: any user-requested CRAN package
+      absent from the resolved tree is resolved individually and merged, so its
+      dependencies enter the install plan even if a future code path drops it.
+  Regression tests added in `test-17usePak.R` (network-free, via mocked
+  `pak::pkg_deps()`).
+
 
 * `test-01packages_testthat.R` (issue 87): the pinned-SHA downgrade test now
   drops the loaded/installed newer `reproducible` before each

--- a/R/pak.R
+++ b/R/pak.R
@@ -1882,6 +1882,18 @@ pakDepsResolve <- function(pkgsForPak, wh, repos, verbose, purge, userPkgs = NUL
   # --- 4. Cache miss: run the full retry + fallback resolution ---
   pak_result <- NULL
 
+  # The batch retry loop below MUTATES `pkgsForPak`, dropping refs that pak
+  # reports as conflicting so the *batch* solver can converge. Those drops are
+  # only valid for the batch: the per-package fallback resolves each ref in
+  # ISOLATION, where cross-package conflicts cannot occur, so it must see the
+  # complete original ref set. Keep an untouched copy for that fallback.
+  # Without this, a CRAN ref pak flagged only as a cascade casualty of an
+  # unrelated unsolvable conflict (e.g. `googledrive: dependency conflict`
+  # triggered by a `quickPlot@development` Remotes clash) is dropped here, then
+  # still installed via `user_pkgFN` in pakDepsToPkgDT() -- but WITHOUT its own
+  # transitive deps (e.g. `gargle`), giving a half-installed, broken namespace.
+  pkgsForPakOrig <- pkgsForPak
+
   for (.pakDepsAttempt in 1:5) {
     pak_result_or_err <- tryCatch(
       list(result = pakCall(pak::pkg_deps(pkgsForPak, dependencies = wh), verbose), err = NULL),
@@ -2045,8 +2057,15 @@ pakDepsResolve <- function(pkgsForPak, wh, repos, verbose, purge, userPkgs = NUL
     messageVerbose("Require Note: pak's batch dependency resolution failed; ",
                    "switching to per-package resolution.",
                    verbose = verbose, verboseLevel = 1)
-    archiveRefs <- grep("^url::", pkgsForPak, value = TRUE)
-    nonArchivePkgs <- pkgsForPak[!grepl("^url::", pkgsForPak)]
+    # Resolve the ORIGINAL ref set (not the conflict-stripped `pkgsForPak`): in
+    # isolation there are no cross-package conflicts, so every ref the user
+    # asked for -- including cascade casualties stripped during the batch retry
+    # -- gets its own dependency subtree resolved. `url::` archive refs that the
+    # retry loop *discovered* (and added to `pkgsForPak`) are still useful as
+    # supplements for archived transitive deps, so carry those forward too.
+    archiveRefs <- unique(c(grep("^url::", pkgsForPak,     value = TRUE),
+                            grep("^url::", pkgsForPakOrig, value = TRUE)))
+    nonArchivePkgs <- pkgsForPakOrig[!grepl("^url::", pkgsForPakOrig)]
     # Reset the per-package cache-hit counter so the summary below reports only
     # this loop's hits. pakPkgDepsCached() caches each ref independently, so a
     # repeat call with only a few changed refs re-resolves online just those.
@@ -2246,6 +2265,39 @@ pakDepsToPkgDT <- function(packages, which, libPaths, standAlone, verbose,
     messageVerbose("pak::pkg_deps: all strategies failed; using direct package list only.",
                    verbose = verbose, verboseLevel = 2)
     return(toPkgDTFull(packages))
+  }
+
+  # 1b. Closure guard for user-requested CRAN packages.
+  # Every package the user asked for must appear in the resolved tree, otherwise
+  # its transitive deps never enter the install plan while the package itself is
+  # still installed via `user_pkgFN` (step 4) -- the "googledrive installed
+  # without gargle" failure mode. A user package can be absent from `pak_result`
+  # when batch resolution dropped it as a cascade casualty of an *unrelated*
+  # unsolvable conflict (pak marks many innocent CRAN packages "dependency
+  # conflict" when a few GitHub Remotes refs clash; pakDepsResolve strips them to
+  # coax the batch solver). Resolve any missing user CRAN package individually --
+  # in isolation there are no cross-package conflicts -- and merge its subtree so
+  # its dependencies (e.g. gargle) become part of the plan. Scoped to plain CRAN
+  # refs: GitHub/url:: refs are never stripped by that handler.
+  userCRANrefs <- packages[!isGH(packages) & !grepl("::", packages) &
+                           !extractPkgName(packages) %in% .basePkgs]
+  if (length(userCRANrefs)) {
+    missingUser <- setdiff(unique(extractPkgName(userCRANrefs)), pak_result$package)
+    if (length(missingUser)) {
+      messageVerbose("Require/pak: ", length(missingUser), " user-requested package(s) ",
+                     "absent from batch resolution (cascade casualties of an unrelated ",
+                     "conflict); resolving their dependency subtrees individually: ",
+                     paste(missingUser, collapse = ", "),
+                     verbose = verbose, verboseLevel = 1)
+      missingRefs <- trimVersionNumber(
+        userCRANrefs[match(missingUser, extractPkgName(userCRANrefs))])
+      extra <- lapply(missingRefs, function(q)
+        tryCatch(pakPkgDepsCached(q, wh, getOption("repos"), verbose, purge, type = type),
+                 error = function(e) NULL))
+      extra <- extra[!vapply(extra, is.null, logical(1))]
+      if (length(extra))
+        pak_result <- rbindlist(c(list(pak_result), extra), fill = TRUE, use.names = TRUE)
+    }
   }
 
   # 2. Flatten all deps sub-tables to get the raw version requirements.

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1570,3 +1570,128 @@ test_that("pinInstalledForPak skips user-version-constrained packages", {
   testthat::expect_true(grepl("^data.table@", out[2]),
     info = "bare user packages with no constraint must be pinned to installed version to keep deps stable")
 })
+
+# ---------------------------------------------------------------------------
+# 18. Cascade-casualty regression (issue: googledrive installed without gargle)
+#
+# When a few GitHub Remotes refs make the BATCH dependency solve unsolvable,
+# pak reports a cascade of innocent CRAN packages as "dependency conflict".
+# pakDepsResolve strips those CRAN refs from `pkgsForPak` to coax the batch
+# solver -- but the per-package fallback must still resolve the ORIGINAL ref
+# set (in isolation there are no cross-package conflicts), otherwise a stripped
+# top-level package (e.g. googledrive) is later installed via `user_pkgFN`
+# WITHOUT its transitive deps (e.g. gargle): a half-installed, broken namespace.
+#
+# These tests are network-free: the batch pak::pkg_deps() call is mocked to
+# throw the real conflict error, and each single-ref call returns a small fake
+# dep tree. Cache writes are redirected to a tempdir via R_REQUIRE_CACHE.
+# ---------------------------------------------------------------------------
+
+# A pak::pkg_deps()-shaped result for a single package. googledrive carries a
+# transitive `gargle` dep (both as a row and in its `deps` sub-table).
+.fakePakTreeForTest <- function(refOrName) {
+  nm <- Require:::extractPkgName(refOrName)
+  emptyDeps <- function()
+    data.frame(ref = character(), type = character(), package = character(),
+               op = character(), version = character(), stringsAsFactors = FALSE)
+  if (identical(nm, "googledrive")) {
+    pkgs <- c("googledrive", "gargle")
+    deps <- list(
+      data.frame(ref = "gargle", type = "imports", package = "gargle",
+                 op = "", version = "", stringsAsFactors = FALSE),
+      emptyDeps())
+  } else {
+    pkgs <- nm
+    deps <- list(emptyDeps())
+  }
+  data.frame(package = pkgs, version = NA_character_, ref = pkgs,
+             direct = pkgs == nm, lib_status = "new",
+             deps = I(deps), stringsAsFactors = FALSE)
+}
+
+# The real attempt-1 error shape: cascade casualties as "dependency conflict",
+# plus the genuine cross-package GitHub conflict that the batch can't solve.
+.fakeBatchConflictErr <- paste(
+  "! error in pak subprocess",
+  "Caused by error: ",
+  "! Could not solve package dependencies:",
+  "* googledrive: dependency conflict",
+  "* data.table: dependency conflict",
+  "* PredictiveEcology/quickPlot@development: Conflicts with quickPlot",
+  sep = "\n")
+
+test_that("pakDepsResolve per-package fallback keeps a cascade-casualty's transitive deps (gargle)", {
+  skip_if_not_installed("pak")
+
+  # 2 GitHub refs remain after the CRAN casualties are stripped, so the batch
+  # still has length > 1 and keeps failing -> the per-package fallback fires.
+  pkgsForPak <- c("googledrive", "data.table",
+                  "PredictiveEcology/quickPlot@development",
+                  "PredictiveEcology/SpaDES.tools@development")
+  wh    <- NA
+  repos <- c(CRAN = "https://cloud.r-project.org")
+
+  mock_pkg_deps <- function(pkg, dependencies = NA, ...) {
+    if (length(pkg) > 1L) stop(.fakeBatchConflictErr, call. = FALSE) # batch unsolvable
+    .fakePakTreeForTest(pkg)                                          # single ref: resolves
+  }
+
+  res <- withr::with_envvar(c(R_REQUIRE_CACHE = tempfile("reqcache")), {
+    withr::with_options(list(Require.purge = TRUE, Require.offlineMode = FALSE), {
+      testthat::with_mocked_bindings(
+        Require:::pakDepsResolve(pkgsForPak, wh, repos, verbose = 0, purge = TRUE),
+        pkg_deps = mock_pkg_deps, .package = "pak")
+    })
+  })
+
+  testthat::expect_false(is.null(res))
+  # The casualty (googledrive) and its transitive dep (gargle) both survive.
+  testthat::expect_true("googledrive" %in% res$package)
+  testthat::expect_true("gargle" %in% res$package,
+    info = "gargle must survive: per-package fallback resolves the ORIGINAL ref set, not the conflict-stripped one")
+})
+
+test_that("pakDepsToPkgDT closure guard re-resolves a user CRAN pkg dropped from the tree (gargle lands in pkgDT)", {
+  skip_if_not_installed("pak")
+
+  # Simulate the batch-success-with-stripped-casualty path: the resolver returns
+  # a tree that does NOT contain googledrive (it was stripped), but googledrive
+  # is a user-requested CRAN package, so the guard must resolve it individually
+  # and bring its dep (gargle) into the plan.
+  packages <- c("googledrive", "data.table")
+
+  # pakDepsResolve returns a tree WITHOUT googledrive/gargle.
+  fake_resolve <- function(pkgsForPak, wh, repos, verbose, purge, userPkgs = NULL,
+                           type = getOption("pkgType")) {
+    data.frame(package = "data.table", version = "1.15.0", ref = "data.table",
+               direct = TRUE, lib_status = "new",
+               deps = I(list(data.frame(ref = character(), type = character(),
+                                        package = character(), op = character(),
+                                        version = character(),
+                                        stringsAsFactors = FALSE))),
+               stringsAsFactors = FALSE)
+  }
+  # The guard resolves the missing googledrive individually.
+  fake_pkgdepscached <- function(query, wh, repos, verbose, purge,
+                                 type = getOption("pkgType")) {
+    if (identical(Require:::extractPkgName(query), "googledrive"))
+      .fakePakTreeForTest("googledrive")
+    else NULL
+  }
+
+  pkgDT <- withr::with_envvar(c(R_REQUIRE_CACHE = tempfile("reqcache")), {
+    withr::with_options(list(Require.purge = TRUE), {
+      testthat::with_mocked_bindings(
+        pakDepsResolve   = fake_resolve,
+        pakPkgDepsCached = fake_pkgdepscached,
+        Require:::pakDepsToPkgDT(packages,
+                                 which = c("Imports", "Depends", "LinkingTo"),
+                                 libPaths = .libPaths(), standAlone = FALSE,
+                                 verbose = 0, purge = TRUE)
+      )
+    })
+  })
+
+  testthat::expect_true("gargle" %in% pkgDT$Package,
+    info = "closure guard must pull a dropped user CRAN package's transitive deps into the plan")
+})


### PR DESCRIPTION
## Problem

A user-requested CRAN package could be installed **without its dependencies** when pak's batch dependency solve was unsolvable.

When a few GitHub `Remotes` refs genuinely conflict (e.g. `PredictiveEcology/quickPlot@development` → `tidyverse/ggplot2` vs a pinned `ggplot2`, and `SpaDES.tools@development` vs `SpaDES.tools`), pak's resolver fails the whole batch and reports a cascade of **innocent** CRAN packages as `"X: dependency conflict"`. In one real `setupProject` run, `pkgsForPak` went from 42 refs → 17 because `pakDepsResolve()` stripped every such CRAN ref (`googledrive`, `RCurl`, `snow`, `gert`, `remotes`, …) to coax the batch solver.

The strip is fine for the **batch**, but:
- the **per-package fallback** then resolved only the *stripped* 17 refs, so `googledrive`'s subtree (hence `gargle`) was never resolved; and
- `googledrive` is a top-level `packages` entry, so it was still installed via `user_pkgFN` in `pakDepsToPkgDT()`.

Result: `googledrive` installed **without `gargle`** → `loadNamespace("googledrive")` fails with *"there is no package called 'gargle'"*, which surfaced downstream as `reproducible::prepInputs()` reporting *"googledrive is required but not yet installed"*.

`gargle` is the package that breaks because it is the only stripped package's transitive dep that nothing else in the project pulls in; most cascade casualties (`sf`, `dplyr`, …) re-enter the tree via the surviving GitHub refs.

## Fix (two complementary changes, no workarounds)

1. **`pakDepsResolve()`** — the per-package fallback now resolves the **original, unstripped** ref set. In isolation there are no cross-package conflicts, so cascade casualties keep their own dependency subtrees. Discovered `url::` archive refs are still carried forward as supplements.
2. **`pakDepsToPkgDT()`** — a **closure guard**: any user-requested CRAN package absent from the resolved tree is resolved individually and merged, so its deps enter the install plan even if some other path drops it (e.g. an over-stripped batch that nonetheless succeeds). Scoped to plain CRAN refs (GitHub/`url::` refs are never stripped by that handler).

## Tests

Network-free regression tests in `test-17usePak.R` (mocked `pak::pkg_deps`):
- per-package fallback keeps a cascade casualty's transitive dep (`gargle`);
- the `pakDepsToPkgDT()` closure guard re-resolves a dropped user CRAN package.

Both **fail on the pre-fix code** and **pass with the fix**.

Full local `devtools::test()`: `FAIL 0 | WARN 1 | SKIP 3 | PASS 657`. The 1 WARN (issue-87 `reproducible (==<curVer>)` install) and 3 SKIPs (`SpaDES.project` not installable here / non-pak `pkgDep` internals) are pre-existing/environmental and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)