### PR TITLE
perf(pak): keep the offline install a parallel batch (dedup CRAN-vs-GitHub refs)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9023
+Version: 2.0.0.9026
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# Require 2.0.0.9026 (development version)
+
+* Performance: the offline (pak download-cache) install path no longer degrades
+  to slow one-at-a-time installs when the resolved set contains a package as
+  both a CRAN ref and a GitHub ref (e.g. `SpaDES.tools (>= 2.0.0)` plus
+  `PredictiveEcology/SpaDES.tools@development`). pak rejects such a batch with a
+  "Conflicts with" error even under `dependencies = FALSE`, which forced
+  `pakOfflineInstall()` into the per-ref fallback (and could cascade into build
+  failures, e.g. `LandR`, because deps were installed in isolation). The
+  CRAN-vs-GitHub/duplicate-CRAN dedup that the online path already applied is
+  now factored into a shared `dedupInstallRefs()` helper and run on the offline
+  path too, so the single parallel `pak::pak()` batch install proceeds. The
+  GitHub ref wins; among duplicate CRAN rows the strictest version pin is kept.
+
 # Require 2.0.0.9023 (development version)
 
 * Fix: a user-requested CRAN package could be installed *without its

--- a/R/pak.R
+++ b/R/pak.R
@@ -971,6 +971,38 @@ pakCachedTarball <- function(pkg, versionSpec = NA_character_,
        version = cachedVer)
 }
 
+# Deduplicate an install set so a single package never appears as BOTH a plain
+# CRAN ref and a GitHub/url:: ref (and never as several plain-CRAN rows).
+# pak::pak() rejects such a list with a "Conflicts with" error EVEN under
+# `dependencies = FALSE` (it still does conflict detection), which forces the
+# slow per-ref ("one-at-a-time") install fallback and loses pak's parallel
+# batch build. Resolution rules (mirroring what the install paths need):
+#   * if any non-CRAN (GitHub/url::) ref exists for a Package, drop its plain
+#     CRAN rows -- the non-CRAN ref is authoritative;
+#   * among remaining same-Package rows, keep the one with the strictest version
+#     constraint (== > <= > < > >= > > > none) so a user pin isn't lost.
+# Operates on a copy; returns the deduplicated data.table. Used by both the
+# offline (cache) and online install paths so they behave identically.
+dedupInstallRefs <- function(toInstall) {
+  if (!NROW(toInstall) || !anyDuplicated(toInstall$Package)) return(toInstall)
+  toInstall <- data.table::copy(toInstall)
+  pfn <- if ("packageFullName" %in% names(toInstall))
+    toInstall$packageFullName else toInstall$Package
+  set(toInstall, NULL, "isNonCRAN", isGH(pfn) | startsWith(pfn, "url::"))
+  toInstall[, hasNonCRAN := any(isNonCRAN), by = Package]
+  # Remove plain CRAN rows when a non-CRAN ref exists for the same package
+  toInstall <- toInstall[!(hasNonCRAN == TRUE & isNonCRAN == FALSE)]
+  ineq <- if ("inequality" %in% names(toInstall))
+    toInstall$inequality else rep(NA_character_, NROW(toInstall))
+  set(toInstall, NULL, ".versionSpecPrio",
+      match(ineq, c("==", "<=", "<", ">=", ">"), nomatch = 6L))
+  setorderv(toInstall, c("Package", ".versionSpecPrio"))
+  # If duplicates still remain (e.g., two GitHub branches), keep the first
+  toInstall <- unique(toInstall, by = "Package")
+  set(toInstall, NULL, c("isNonCRAN", "hasNonCRAN", ".versionSpecPrio"), NULL)
+  toInstall[]
+}
+
 # Offline install via pak: resolve each user package to a local tarball in
 # pak's cache and install via `local::path` refs (which require no network).
 # Returns the (possibly-modified) pkgDT with `installed`, `Version`,
@@ -981,6 +1013,11 @@ pakOfflineInstall <- function(pkgDT, libPaths, verbose = getOption("Require.verb
   if (!requireNamespace("pak", quietly = TRUE)) stop("Please install pak")
   toInstall <- pkgDT[needInstall == .txtInstall]
   if (!NROW(toInstall)) return(pkgDT)
+  # Drop CRAN-vs-GitHub (and duplicate-CRAN) collisions BEFORE the batch
+  # pak::pak() so the single parallel install succeeds instead of degrading to
+  # the slow per-ref fallback. (The online path, pakInstallFiltered, does the
+  # same via dedupInstallRefs().)
+  toInstall <- dedupInstallRefs(toInstall)
 
   ## We used to call `pakResetSubprocess()` here, hoping that a wedged
   ## subprocess after a failed `pakInstallFiltered` plan would otherwise
@@ -3119,39 +3156,13 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
   toInstall <- pkgDT[needInstall == .txtInstall]
   if (!NROW(toInstall)) return(pkgDT)
 
-  # Deduplicate: if the same Package appears as both a CRAN ref and a GitHub/url:: ref,
-  # keep only the non-CRAN ref. pak::pak() would reject the list with a "Conflicts with"
-  # error if both "any::SpaDES.tools" (CRAN) and "owner/SpaDES.tools@branch" (GitHub)
-  # appear together, because dependencies = FALSE still does conflict detection.
-  if (anyDuplicated(toInstall$Package)) {
-    toInstall[, isNonCRAN := isGH(packageFullName) | startsWith(packageFullName, "url::")]
-    toInstall[, hasNonCRAN := any(isNonCRAN), by = Package]
-    # Remove plain CRAN rows when a non-CRAN ref exists for the same package
-    toInstall <- toInstall[!(hasNonCRAN == TRUE & isNonCRAN == FALSE)]
-    # Among multiple plain-CRAN rows for the same Package (e.g. one row carries
-    # the user's "(<= 0.15.8)" upper-bound and a separate row carries a
-    # transitive dep's "(>= 0.15.1)" lower-bound -- trimRedundancies keeps both
-    # because they are complementary, not redundant), pick the row with the
-    # strictest constraint before unique(by = "Package") collapses them.
-    # Without this sort, unique() arbitrarily keeps whichever row sorted first
-    # in pkgDT -- typically the transitive ">=" row, since dep tree rows are
-    # appended after user rows. The user's "<=" pin is then dropped, the
-    # downstream gsub("\\(>=...\\)", "") strips the row to a bare name, the
-    # any:: prefix turns it into "any::stringfish", and pak silently installs
-    # the latest (constraint-violating) version -- symptom seen in the field
-    # as `Install("stringfish (<= 0.15.8)")` producing stringfish 0.19.0.
-    # Strictness order:  ==  >  <=  >  <  >  >=  >  >  >  none.
-    # equalsToAt() and lessThanToAt() (called below) translate ==/<=/< into
-    # exact "@version" pins; >= and > get stripped to bare names so any::pkg
-    # ends up resolving to latest.  Keeping the strictest row therefore
-    # ensures the install is correctly pinned where the user asked for one.
-    toInstall[, .versionSpecPrio := match(
-      inequality, c("==", "<=", "<", ">=", ">"), nomatch = 6L)]
-    setorderv(toInstall, c("Package", ".versionSpecPrio"))
-    # If duplicates still remain (e.g., two GitHub branches), keep first
-    toInstall <- unique(toInstall, by = "Package")
-    toInstall[, c("isNonCRAN", "hasNonCRAN", ".versionSpecPrio") := NULL]
-  }
+  # Deduplicate CRAN-vs-GitHub/url:: (and duplicate-CRAN) collisions for the same
+  # Package: pak::pak() rejects e.g. both "any::SpaDES.tools" (CRAN) and
+  # "owner/SpaDES.tools@branch" (GitHub) with a "Conflicts with" error even under
+  # dependencies = FALSE. The strictest version constraint is kept among plain-CRAN
+  # duplicates so a user pin (e.g. "stringfish (<= 0.15.8)") isn't dropped. See
+  # dedupInstallRefs() (shared with the offline path, pakOfflineInstall).
+  toInstall <- dedupInstallRefs(toInstall)
 
   # Pre-install integrity check: abort the install for any toInstall package
   # whose installed DESCRIPTION names a hard dep that is neither currently

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1695,3 +1695,66 @@ test_that("pakDepsToPkgDT closure guard re-resolves a user CRAN pkg dropped from
   testthat::expect_true("gargle" %in% pkgDT$Package,
     info = "closure guard must pull a dropped user CRAN package's transitive deps into the plan")
 })
+
+# ---------------------------------------------------------------------------
+# 19. dedupInstallRefs: prevent the CRAN-vs-GitHub "Conflicts with" self-conflict
+#     that forces pak into the slow one-at-a-time install fallback.
+#
+# When a package appears in the install set as BOTH a plain-CRAN ref and a
+# GitHub ref (e.g. `SpaDES.tools (>= 2.0.0)` from a module's reqdPkgs AND
+# `PredictiveEcology/SpaDES.tools@development`), pak::pak() rejects the whole
+# batch with "Conflicts with" even under dependencies = FALSE -- so the offline
+# installer degrades to installing one ref at a time (very slow) instead of one
+# parallel batch. dedupInstallRefs() drops the redundant CRAN row, keeping the
+# GitHub ref, so the parallel batch install proceeds.
+# ---------------------------------------------------------------------------
+test_that("dedupInstallRefs keeps the GitHub ref and drops the same-package CRAN ref", {
+  dt <- data.table::data.table(
+    Package         = c("SpaDES.tools", "SpaDES.tools", "DBI"),
+    packageFullName = c("SpaDES.tools (>= 2.0.0)",
+                        "PredictiveEcology/SpaDES.tools@development", "DBI"),
+    inequality      = c(">=", NA, NA),
+    needInstall     = "install")
+  out <- Require:::dedupInstallRefs(dt)
+
+  testthat::expect_false(anyDuplicated(out$Package) > 0)
+  testthat::expect_equal(
+    out[Package == "SpaDES.tools"]$packageFullName,
+    "PredictiveEcology/SpaDES.tools@development",
+    info = "the GitHub ref must win so pak does not see a CRAN-vs-GitHub conflict")
+  testthat::expect_true("DBI" %in% out$Package)   # untouched
+})
+
+test_that("dedupInstallRefs keeps the strictest constraint among duplicate CRAN rows", {
+  dt <- data.table::data.table(
+    Package         = c("stringfish", "stringfish"),
+    packageFullName = c("stringfish (<= 0.15.8)", "stringfish (>= 0.15.1)"),
+    inequality      = c("<=", ">="),
+    needInstall     = "install")
+  out <- Require:::dedupInstallRefs(dt)
+  testthat::expect_equal(nrow(out), 1L)
+  testthat::expect_equal(out$packageFullName, "stringfish (<= 0.15.8)",
+    info = "the user's '<=' pin must survive (== > <= > < > >= > >), not the transitive '>='")
+})
+
+test_that("dedupInstallRefs is a no-op when there are no duplicate packages", {
+  dt <- data.table::data.table(
+    Package         = c("DBI", "terra"),
+    packageFullName = c("DBI", "terra (>= 1.7)"),
+    inequality      = c(NA, ">="),
+    needInstall     = "install")
+  out <- Require:::dedupInstallRefs(dt)
+  testthat::expect_equal(nrow(out), 2L)
+  testthat::expect_setequal(out$Package, c("DBI", "terra"))
+})
+
+test_that("dedupInstallRefs handles a toInstall with no inequality column", {
+  dt <- data.table::data.table(
+    Package         = c("SpaDES.tools", "SpaDES.tools"),
+    packageFullName = c("SpaDES.tools", "PredictiveEcology/SpaDES.tools@development"),
+    needInstall     = "install")
+  out <- Require:::dedupInstallRefs(dt)
+  testthat::expect_equal(nrow(out), 1L)
+  testthat::expect_equal(out$packageFullName,
+                         "PredictiveEcology/SpaDES.tools@development")
+})


### PR DESCRIPTION
## Problem

The offline (pak download-cache) install path degraded to **installing one package at a time** — very slow — whenever the resolved set contained a package as **both a CRAN ref and a GitHub ref**, e.g. `SpaDES.tools (>= 2.0.0)` (from a module's `reqdPkgs`) together with `PredictiveEcology/SpaDES.tools@development`.

`pak::pak()` rejects such a list with a `Conflicts with` error **even under `dependencies = FALSE`** (it still runs conflict detection), so `pakOfflineInstall()` fell back to its per-ref loop. Observed in the field:

```
pakOfflineInstall: batch resolver reported 'Conflicts with' (likely a pak self-conflict on an exact-pin ref); retrying each ref one-at-a-time…
* PredictiveEcology/SpaDES.tools: Conflicts with SpaDES.tools@2.1.1
```

Beyond being slow, the per-ref isolation also caused **build failures** (e.g. `LandR` built before its deps were present).

## Root cause

The online install path (`pakInstallFiltered`) **already deduped** CRAN-vs-GitHub refs to prevent exactly this — but the offline cache path (`pakOfflineInstall`) did not. So only the cache shortcut tripped the conflict and lost pak's parallel batch build.

## Fix

- Factor the existing dedup into a shared **`dedupInstallRefs()`** helper: when a package has a GitHub/`url::` ref, drop its plain-CRAN rows (the non-CRAN ref wins); among duplicate CRAN rows, keep the strictest version pin (`== > <= > < > >= > >`) so a user pin isn't lost.
- Call it in `pakOfflineInstall()` **before** the batch `pak::pak()`, so the single **parallel** install proceeds.
- Refactor `pakInstallFiltered()` to use the same helper (behavior-preserving).

## Tests

4 network-free unit tests for `dedupInstallRefs()` in `test-17usePak.R` (GitHub-wins, strictest-CRAN-pin, no-op when unique, missing-`inequality`-column).

Full local `devtools::test()`: `FAIL 0 | WARN 1 | SKIP 3 | PASS 666`. The 1 WARN (issue-87 `reproducible (==…)` install) and 3 SKIPs (`SpaDES.project` not installable here / non-pak internals) are pre-existing/environmental and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)