### PR TITLE
fix(pak): fold Require.noRemotes into the resolver cache key

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9028
+Version: 2.0.0.9029
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# Require 2.0.0.9029 (development version)
+
+* `Require.noRemotes` is now part of the pak resolver-cache key. `noRemotes`
+  rewrites `owner/repo@branch` specs to bare names that resolve from `repos`
+  (r-universe) and, crucially, repo resolution does NOT follow `Remotes:` --
+  whereas a GitHub-ref resolution does. The two produce structurally different
+  dep trees, so a `noRemotes` run must not reuse a pre-`noRemotes` (GitHub-ref)
+  resolution cached on disk. Previously it could, and the install then fell back
+  to slow one-at-a-time GitHub source builds with `Conflicts with` errors (pak
+  following each cached package's `Remotes:`). The flag is folded into the key
+  only when `TRUE`, so existing `noRemotes = FALSE` cache entries are unchanged.
+
 # Require 2.0.0.9028 (development version)
 
 * New option `Require.noRemotes` (default `FALSE`). When `TRUE`, GitHub-style

--- a/R/pak.R
+++ b/R/pak.R
@@ -1783,7 +1783,8 @@ pakWhoNeeds <- function(pkg, pak_result = NULL) {
 .pakDepsCacheTTL <- 24 * 3600   # 24 hours default
 
 pakDepsCacheKey <- function(pkgsForPak, wh, repos, userPkgs = NULL,
-                            type = getOption("pkgType")) {
+                            type = getOption("pkgType"),
+                            noRemotes = isTRUE(getOption("Require.noRemotes", FALSE))) {
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   # coerce to character vectors: options(repos = list(...)) is a supported
@@ -1813,6 +1814,19 @@ pakDepsCacheKey <- function(pkgsForPak, wh, repos, userPkgs = NULL,
   # quietly install the wrong (latest) version.
   if (!is.null(userPkgs))
     payload$userPkgs <- sort(as.character(unlist(userPkgs, use.names = FALSE)))
+  # `noRemotes` (Require.noRemotes = TRUE) rewrites `owner/repo@branch` specs to
+  # bare names that resolve from `repos` (r-universe) instead of being cloned and
+  # built from GitHub source -- and crucially, repo resolution does NOT follow the
+  # `Remotes:` field, whereas a GitHub-ref resolution does. The two therefore
+  # produce structurally different dep trees (bare/standard refs vs `owner/repo`
+  # refs that drag in Remotes). pkgsForPak usually already differs between the two
+  # (stripped vs not), but fold the flag in explicitly so a noRemotes run can NEVER
+  # reuse a pre-noRemotes (GitHub-ref) cache entry -- the exact stale-reuse that
+  # made a noRemotes install fall back to slow per-ref GitHub source builds with
+  # `Conflicts with` errors. Added only when TRUE so existing (noRemotes = FALSE)
+  # cache keys are unchanged (back-compat), mirroring the `userPkgs` handling.
+  if (isTRUE(noRemotes))
+    payload$noRemotes <- TRUE
   saveRDS(payload, tmp, compress = FALSE)
   unname(tools::md5sum(tmp))
 }

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1814,3 +1814,32 @@ test_that("isExplicitShaPin qualifies only bare GitHub @sha refs", {
   testthat::expect_equal(qualifies,
                          c(TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, FALSE))
 })
+
+# ---------------------------------------------------------------------------
+# Require.noRemotes must be part of the resolver cache key. noRemotes rewrites
+# GitHub specs to bare names that resolve from `repos` (no Remotes-following),
+# producing a structurally different dep tree than a GitHub-ref resolution
+# (which DOES follow Remotes). Without folding the flag into the key, a noRemotes
+# run could reuse a stale pre-noRemotes (GitHub-ref) resolution -> the install
+# fell back to slow per-ref GitHub source builds with `Conflicts with` errors.
+# Added only when TRUE, so noRemotes = FALSE keys are unchanged (back-compat).
+# ---------------------------------------------------------------------------
+test_that("pakDepsCacheKey folds in Require.noRemotes (and is back-compatible)", {
+  pk    <- c("LandR", "pemisc", "SpaDES.tools")
+  wh    <- c("Imports", "Depends", "LinkingTo")
+  repos <- c(CRAN = "https://cloud.r-project.org")
+
+  kFalse <- Require:::pakDepsCacheKey(pk, wh, repos, noRemotes = FALSE)
+  kTrue  <- Require:::pakDepsCacheKey(pk, wh, repos, noRemotes = TRUE)
+  testthat::expect_false(identical(kFalse, kTrue))   # distinct entries
+
+  # Back-compat: with the option FALSE (the default), the key must be byte-for-
+  # byte the pre-fix key (the noRemotes field is only added when TRUE).
+  withr::with_options(list(Require.noRemotes = FALSE), {
+    testthat::expect_identical(Require:::pakDepsCacheKey(pk, wh, repos), kFalse)
+  })
+  # The default arg reads the option.
+  withr::with_options(list(Require.noRemotes = TRUE), {
+    testthat::expect_identical(Require:::pakDepsCacheKey(pk, wh, repos), kTrue)
+  })
+})


### PR DESCRIPTION
## Symptom

A `Require.noRemotes = TRUE` install (large SpaDES.project workshop setup) was very slow: `pakOfflineInstall: batch resolver reported 'Conflicts with' ... retrying each ref one-at-a-time`, then 150+ packages installed one at a time with GitHub source builds and `Failed to build SpaDES.core (deps not available)`.

## Root cause — stale cache reuse, not noRemotes itself

`noRemotes` rewrites `owner/repo@branch` specs to bare names that resolve from `repos` (r-universe). I verified that **repo resolution never follows `Remotes:`** (`pkg_deps("LandR", dependencies = NA)` → 107 deps, zero GitHub/Remotes), whereas a GitHub-ref resolution *does*. So the two paths produce structurally different dep trees.

The run's log said `using cache (179 packages)`. Inspecting the on-disk resolver cache, that entry is a **179-package resolution with 15 GitHub refs** (`PredictiveEcology/LandR`, `pemisc`, `SpaDES.tools`, `reproducible`, `quickPlot`, …) built **before `noRemotes` was on**. The `noRemotes` run reused it, so the install used `github::owner/repo@sha` refs → pak followed each cached package's `Remotes:` → self-conflicts on the exact pins → the slow per-ref fallback + source builds.

A *fresh* `noRemotes` resolution of the same packages resolves to **all-bare repo refs** (zero GitHub, zero Remotes) — i.e. the path is fast and clean when it doesn't reuse the stale entry.

## Fix

Fold `Require.noRemotes` into `pakDepsCacheKey()` so a `noRemotes` run can never reuse a non-`noRemotes` (GitHub-ref) cache entry, and vice versa. The flag is added to the key **only when `TRUE`**, so existing `noRemotes = FALSE` keys are byte-identical (back-compat). The default arg reads `getOption("Require.noRemotes")`, so the resolver / per-package / invalidate callers pick it up with no signature changes.

This makes the stale 179-package GitHub entry **unreachable** from a `noRemotes` run — so it auto-fixes the reported case without anyone manually clearing the cache.

## Verification

- `noRemotes` TRUE vs FALSE keys differ; FALSE key is byte-identical to pre-fix (regression test `pakDepsCacheKey folds in Require.noRemotes ...`).
- Component checks: the `noRemotes` strip fires on current code, and a fresh resolution of the user's packages yields all-bare repo refs.

Bump `2.0.0.9028` → `2.0.0.9029`.

> Note: this is the cache-key fix the maintainer asked for. A complementary belt-and-braces option (strip GitHub refs in the offline install path when `noRemotes` is on) was discussed but deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)