### PR TITLE
fix(pak): only take the offline cache shortcut in genuine offlineMode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9028
+Version: 2.0.0.9029
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# Require 2.0.0.9029 (development version)
+
+* The "all packages already in pak's download cache" shortcut no longer routes
+  an **online** install into the bespoke offline installer (`pakOfflineInstall`).
+  That installer hands pak every dependency-tree node as a `pkg@version`
+  exact-pin, which self-conflicts in pak's resolver
+  (`openssl@2.4.2: Conflicts with openssl@2.4.2`) and collapses to a slow
+  one-at-a-time per-ref fallback -- very visible on large `noRemotes` installs.
+  The shortcut now fires only in genuine `offlineMode`; otherwise the install
+  goes through pak's own resolve+install (`pakInstallFiltered`), which already
+  uses pak's download cache, orders builds natively, and carries the retry /
+  error-handling catches -- and still falls back to the offline cache installer
+  if the network turns out to be down.
+
 # Require 2.0.0.9028 (development version)
 
 * New option `Require.noRemotes` (default `FALSE`). When `TRUE`, GitHub-style

--- a/R/Require2.R
+++ b/R/Require2.R
@@ -491,9 +491,20 @@ Require <- function(packages,
           ## installed packages. Skip the shortcut when the user
           ## explicitly asked for `install = "force"` or set
           ## `purge = TRUE`; those signal "ignore the cache".
-          forceOnline <- identical(install, "force") || isTRUE(purge)
-          useCacheShortcut <- isTRUE(getOption("Require.offlineMode")) ||
-            (!forceOnline && allInPakCache(pkgDT))
+          # Use the bespoke offline cache-install shortcut (pakOfflineInstall) ONLY
+          # in genuine offline mode. It used to ALSO fire whenever every package was
+          # already in pak's download cache (allInPakCache) -- a "skip the metadata
+          # refresh" optimization -- but that routes a perfectly ONLINE install into
+          # the bespoke exact-pin batch, which hands pak every dep-tree node as a
+          # `pkg@version` ref and self-conflicts in pak's resolver
+          # ("openssl@2.4.2: Conflicts with openssl@2.4.2"), collapsing to the slow
+          # per-ref one-at-a-time fallback. When online, prefer pak's own
+          # resolve+install (pakInstallFiltered): it uses pak's download cache
+          # anyway, orders builds natively, and carries the retry/error-handling
+          # catches (pakRetryLoop, pakErrorHandling). pakOfflineInstall remains for
+          # true offlineMode, and pakInstallFiltered's recovery block below still
+          # falls back to it if the network turns out to be down.
+          useCacheShortcut <- isTRUE(getOption("Require.offlineMode"))
           if (useCacheShortcut) {
             if (!isTRUE(getOption("Require.offlineMode"))) {
               messageVerbose("All requested packages are in the pak ",


### PR DESCRIPTION
## Symptom
A large `noRemotes` install crawls: `pakOfflineInstall: batch resolver reported 'Conflicts with' ... retrying each ref one-at-a-time`, then 130+ packages install one at a time.

## Root cause
The install dispatch routes an **online** install into the bespoke offline installer. The "all packages already in pak's download cache" shortcut (`allInPakCache`) sent the install to `pakOfflineInstall` even when online — a "skip pak's metadata refresh" optimization. But `pakOfflineInstall` hands pak **every dependency-tree node as a `pkg@version` exact-pin**, which self-conflicts in pak's resolver. Reproduced down to a single ref against the user's cache:

```r
pak::pak("openssl@2.4.2", dependencies = FALSE)
#> ! Could not solve package dependencies:
#> * openssl@2.4.2: Conflicts with openssl@2.4.2
```

When the batch dies, Require falls into its own per-ref one-at-a-time recovery → the slow crawl.

## Fix
Gate the shortcut on **genuine `offlineMode` only**. When online, the install goes through pak's own resolve+install (`pakInstallFiltered`), which:
- uses pak's download cache anyway (no needless re-download),
- orders builds natively (pak resolves the tree instead of being handed every pinned node),
- carries the retry/error-handling catches (`pakRetryLoop`, `pakErrorHandling`),
- and its existing recovery block still falls back to `pakOfflineInstall` if the network turns out to be down.

This favours pak's own API over Require re-implementing install/resolve (per the maintainer's "use pak's functions, don't write our own" guidance). `pakOfflineInstall` is unchanged and still used for true `offlineMode`; `allInPakCache()` is retained (still unit-tested) but no longer gates the dispatch.

## Testing
- Parse-checked; `offlineMode` tests (test-12) and `allInPakCache` unit tests (test-15) are unaffected (the function and the explicit-`offlineMode` path are unchanged).
- **Real-world validation pending** — needs a re-run of the maintainer's SpaDES.project `noRemotes` setup (too large to run in CI here). Expected: pak resolves once from r-universe, installs cached binaries in batches, no per-ref crawl.

## Notes
- Separate from #168 (noRemotes in cache key), which is a valid defensive fix being kept.
- Surfaces (rather than hides) the unsatisfiable `reproducible (>= 3.1.1.9054)` constraint via pak's normal resolver + Require's drop/warn — that constraint isn't available on r-universe/CRAN and is a content issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)