### PR TITLE
fix(pak): noRemotes install — combine offline-shortcut gating (#169) + >= upgrade (#170)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,17 @@
   Such refs are now pinned to the version pak resolved (`pkg@<version>`), which
   pak installs regardless of the upgrade flag. Refs with no resolved version
   known fall through to the previous strip behaviour.
+* The "all packages already in pak's download cache" shortcut no longer routes
+  an **online** install into the bespoke offline installer (`pakOfflineInstall`).
+  That installer hands pak every dependency-tree node as a `pkg@version`
+  exact-pin, which self-conflicts in pak's resolver
+  (`openssl@2.4.2: Conflicts with openssl@2.4.2`) and collapses to a slow
+  one-at-a-time per-ref fallback -- very visible on large `noRemotes` installs.
+  The shortcut now fires only in genuine `offlineMode`; otherwise the install
+  goes through pak's own resolve+install (`pakInstallFiltered`), which already
+  uses pak's download cache, orders builds natively, and carries the retry /
+  error-handling catches -- and still falls back to the offline cache installer
+  if the network turns out to be down.
 
 # Require 2.0.0.9028 (development version)
 

--- a/R/Require2.R
+++ b/R/Require2.R
@@ -491,9 +491,20 @@ Require <- function(packages,
           ## installed packages. Skip the shortcut when the user
           ## explicitly asked for `install = "force"` or set
           ## `purge = TRUE`; those signal "ignore the cache".
-          forceOnline <- identical(install, "force") || isTRUE(purge)
-          useCacheShortcut <- isTRUE(getOption("Require.offlineMode")) ||
-            (!forceOnline && allInPakCache(pkgDT))
+          # Use the bespoke offline cache-install shortcut (pakOfflineInstall) ONLY
+          # in genuine offline mode. It used to ALSO fire whenever every package was
+          # already in pak's download cache (allInPakCache) -- a "skip the metadata
+          # refresh" optimization -- but that routes a perfectly ONLINE install into
+          # the bespoke exact-pin batch, which hands pak every dep-tree node as a
+          # `pkg@version` ref and self-conflicts in pak's resolver
+          # ("openssl@2.4.2: Conflicts with openssl@2.4.2"), collapsing to the slow
+          # per-ref one-at-a-time fallback. When online, prefer pak's own
+          # resolve+install (pakInstallFiltered): it uses pak's download cache
+          # anyway, orders builds natively, and carries the retry/error-handling
+          # catches (pakRetryLoop, pakErrorHandling). pakOfflineInstall remains for
+          # true offlineMode, and pakInstallFiltered's recovery block below still
+          # falls back to it if the network turns out to be down.
+          useCacheShortcut <- isTRUE(getOption("Require.offlineMode"))
           if (useCacheShortcut) {
             if (!isTRUE(getOption("Require.offlineMode"))) {
               messageVerbose("All requested packages are in the pak ",


### PR DESCRIPTION
Combines the two Require fixes for the `noRemotes` workshop install into one branch (clean single version bump, no #169/#170 DESCRIPTION/NEWS collision). Supersedes #169 and #170 — merge **this** instead of those two.

Needs the SpaDES.project repos fix (PredictiveEcology/SpaDES.project#111) to be useful: without it, `setupProject` drops the unnamed r-universe repo and nothing resolves.

## Included
1. **Offline-shortcut gating (was #169).** The `allInPakCache` shortcut no longer routes an *online* install into `pakOfflineInstall`'s bespoke exact-pin batch (which self-conflicts: `reproducible@X: Conflicts with reproducible@X`, plus a large dependency-conflict cascade, and collapses to a slow per-ref crawl). It now fires only in genuine `offlineMode`; otherwise the install goes through pak's own resolve+install (`pakInstallFiltered`), which still uses pak's download cache and keeps the retry/error-handling catches. Confirmed needed: a full `global.R` run with *everything cached* takes the offline path and fails; the earlier "1m16s success" only happened because not everything was cached (→ online path).
2. **`>=` / `>` upgrade (was #170).** `Install("reproducible (>= 3.1.1.9054)")` kept the installed `3.1.1` because the constraint was stripped to `any::reproducible` + `upgrade = FALSE` (pak treats that as "any installed version satisfies"). Such refs are now pinned to the version pak resolved (`pkg@<version>`), matching `pak::pak("pkg")`.

Version `2.0.0.9028` → `2.0.0.9029`. Tests from both fixes included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)