### PR TITLE
chore: bump 2.0.0.9029 -> 2.0.0.9030 to force r-universe rebuild

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9029
+Version: 2.0.0.9030
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Require 2.0.0.9030 (development version)
+
+* Version bump only (no functional change): several `noRemotes`-related fixes
+  (offline-shortcut gating, `>=` upgrade pinning) all landed at `2.0.0.9029`, so
+  installs already holding a `9029` would not pick up the merged build. Bumping
+  to `9030` forces r-universe to rebuild and lets `pak`/`Require` upgrade cleanly.
+
 # Require 2.0.0.9029 (development version)
 
 * The "all packages already in pak's download cache" shortcut no longer routes


### PR DESCRIPTION
Version bump only — **no code change**.

The `noRemotes` fixes (#169 offline-shortcut gating, #170 `>=` upgrade pinning) all merged at `2.0.0.9029` (each branch independently bumped to the same number). Because pak compares version numbers:
- a machine already holding a `9029` build won't upgrade to development's `9029`, and
- r-universe may not rebuild on a same-version merge, so the served `9029` can lag the last merge.

Bumping to `9030` supersedes every `9029`, forces an r-universe rebuild, and lets `pak::pak(c("Require", ...))` (e.g. from `global.R`) pull the complete, fixed build everywhere without `?reinstall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)