### PR TITLE
feat: warn to restart R when a loaded version is insufficient but a satisfying one is installed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9030
+Version: 2.0.0.9031
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# Require 2.0.0.9031 (development version)
+
+* `Require()`/`Install()` now warn to restart R when a package is installed at a
+  version that satisfies the request but an OLDER, insufficient version is still
+  loaded in the session. This happens when a dependency (e.g. `reproducible`) is
+  pulled in via another package's `Imports` from a different library before the
+  satisfying version is installed -- R can't hot-swap a loaded namespace, so the
+  session keeps using the stale version (and `find.package()` returns its path)
+  until restart. Previously this was silent. (`flagRestartForLoadedInsufficient()`,
+  surfaced through the existing "Please restart R" warning.)
+
 # Require 2.0.0.9030 (development version)
 
 * Version bump only (no functional change): several `noRemotes`-related fixes

--- a/R/Require2.R
+++ b/R/Require2.R
@@ -568,6 +568,7 @@ Require <- function(packages,
     }
 
     pkgDT <- needToRestartR(pkgDT)
+    pkgDT <- flagRestartForLoadedInsufficient(pkgDT)
     whRestartNeeded <- which(grepl("restart", pkgDT$installResult))
     if  (length(whRestartNeeded)) {
       warning(.txtPleaseRestart, "; ", paste(pkgDT[whRestartNeeded]$Package, collapse = ", "),
@@ -4516,6 +4517,44 @@ clearErrorReadRDSFile <- function(mess, libPath = .libPaths()[1]) {
   }
 }
 
+
+# A package can end up installed at a version that satisfies the request while an
+# OLDER, insufficient version is still LOADED in the session -- e.g. a dependency
+# (reproducible) pulled in via another package's `Imports` from a different
+# library before the satisfying version was installed. R cannot hot-swap a loaded
+# namespace, so the session keeps using the stale version (and `find.package()`
+# returns its path) until R is restarted. Flag those rows with an installResult
+# containing "restart" so the existing "Please restart R" warning fires -- without
+# this, Require silently installs the new version and the user keeps running the
+# old one. Fires whenever the LOADED version fails the constraint but the on-disk
+# (installed) version meets it, regardless of whether the install happened this
+# call (covers a satisfying version already on disk from a prior run too).
+flagRestartForLoadedInsufficient <- function(pkgDT) {
+  if (!NROW(pkgDT) ||
+      !all(c("Package", "versionSpec", "inequality", "Version") %in% names(pkgDT)))
+    return(pkgDT)
+  loaded <- setdiff(loadedNamespaces(), .basePkgs)
+  if (!length(loaded)) return(pkgDT)
+  for (i in seq_len(NROW(pkgDT))) {
+    pkg <- pkgDT[["Package"]][i]
+    if (!pkg %in% loaded) next
+    vSpec <- pkgDT[["versionSpec"]][i]
+    ineq  <- pkgDT[["inequality"]][i]
+    if (is.na(vSpec) || !nzchar(vSpec) || is.na(ineq) || !nzchar(ineq)) next
+    loadedVer <- tryCatch(as.character(getNamespaceVersion(pkg)),
+                          error = function(e) NA_character_)
+    if (is.na(loadedVer) || !nzchar(loadedVer)) next
+    if (isTRUE(compareVersion2(loadedVer, vSpec, ineq))) next     # loaded already OK
+    instVer <- pkgDT[["Version"]][i]
+    if (!is.na(instVer) && nzchar(instVer) && !identical(loadedVer, instVer) &&
+        isTRUE(compareVersion2(instVer, vSpec, ineq))) {
+      set(pkgDT, i, "installResult",
+          paste0("Need to restart R (loaded ", loadedVer, " < required ",
+                 ineq, " ", vSpec, "; ", instVer, " installed)"))
+    }
+  }
+  pkgDT
+}
 
 needToRestartR <- function(pkgDT) {
   whNeedInstall <- pkgDT[["needInstall"]] %in% .txtInstall

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1850,3 +1850,39 @@ test_that(">= refs are pinned to the pak-resolved version (not stripped to any::
   v2 <- unname(m[Require:::extractPkgName(pkgs2)])
   testthat::expect_true(is.na(v2))   # not pinned; downstream strip handles it
 })
+
+# ---------------------------------------------------------------------------
+# flagRestartForLoadedInsufficient: a package can be installed at a satisfying
+# version while an OLDER, insufficient version is still LOADED (e.g. a dep pulled
+# in via another package's Imports from a different library before the new
+# version was installed). R can't hot-swap a loaded namespace, so Require now
+# flags these so the "Please restart R" warning fires.
+# ---------------------------------------------------------------------------
+test_that("flagRestartForLoadedInsufficient flags loaded-but-insufficient, leaves others", {
+  loadedVer <- as.character(getNamespaceVersion("data.table"))  # data.table is loaded in tests
+  hi <- "9999.0.0"
+
+  # loaded data.table fails (>= 9999.0.0) but the on-disk Version meets it -> restart
+  d1 <- data.table::data.table(Package = "data.table", versionSpec = hi,
+                               inequality = ">=", Version = hi, installResult = "OK")
+  o1 <- Require:::flagRestartForLoadedInsufficient(d1)
+  testthat::expect_match(o1$installResult, "restart", fixed = TRUE)
+
+  # loaded version already satisfies -> untouched
+  d2 <- data.table::data.table(Package = "data.table", versionSpec = "0.0.1",
+                               inequality = ">=", Version = loadedVer, installResult = "OK")
+  testthat::expect_identical(
+    Require:::flagRestartForLoadedInsufficient(d2)$installResult, "OK")
+
+  # package not loaded -> untouched
+  d3 <- data.table::data.table(Package = "notLoadedPkgXYZ", versionSpec = hi,
+                               inequality = ">=", Version = hi, installResult = "OK")
+  testthat::expect_identical(
+    Require:::flagRestartForLoadedInsufficient(d3)$installResult, "OK")
+
+  # no constraint -> untouched (a bare loaded package is never "insufficient")
+  d4 <- data.table::data.table(Package = "data.table", versionSpec = NA_character_,
+                               inequality = NA_character_, Version = loadedVer, installResult = "OK")
+  testthat::expect_identical(
+    Require:::flagRestartForLoadedInsufficient(d4)$installResult, "OK")
+})


### PR DESCRIPTION
## Motivation
Tracked down during the `noRemotes` workshop debugging: `Require::Install("reproducible (>= 3.1.1.9054)")` installs `3.1.1.9056` into the project library, yet `packageVersion("reproducible")` reports `3.1.1.9043`.

Cause: `SpaDES.project` has `Imports: reproducible`, so `reproducible` loads (from a stale copy in the base library) the moment `setupProject()` runs — **before** the project library's satisfying version is installed. R never hot-swaps a loaded namespace, and `find.package()` returns the loaded path, so the session keeps using the stale `9043`. Require installed the right version but said nothing about needing a restart.

## Change
`flagRestartForLoadedInsufficient()`: after install, for any package whose **loaded** version fails its constraint while the **on-disk (installed)** version meets it, set `installResult` to e.g. `Need to restart R (loaded 3.1.1.9043 < required >= 3.1.1.9054; 3.1.1.9056 installed)`. The existing restart-warning path (`Require2.R` ~571, already greps `installResult` for `"restart"`) then emits "Please restart R …". Fires whether or not the install happened this call (also catches a satisfying version already on disk from a prior run).

No behaviour change beyond the warning; the package is still correctly installed.

Regression test in `test-17usePak.R` (loaded-but-insufficient → flagged; already-satisfying / not-loaded / no-constraint → untouched).

Bump `2.0.0.9030` → `2.0.0.9031`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)