### PR TITLE
fix(pak): failure-triggered fallback for the bioconductor.org/config.yaml fetch error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9031
+Version: 2.0.0.9032
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,14 +3,19 @@
 * Resilience to the transient
   `cannot open URL 'http://bioconductor.org/config.yaml'` failure. pak/pkgcache
   fetch the Bioconductor config at startup, and the entire pak call dies when
-  bioc.org is unreachable (network blip, firewall, bioc downtime). Require now
-  points pak at pkgcache's own bundled bioc config (`R_BIOC_CONFIG_URL` file://)
-  and pins `R_BIOC_VERSION` so it never reaches the network -- set at load and
-  before every Require pak call, only when unset (respects a user's explicit
-  values) and only when the bundled fixture is found. Note: a *direct*
-  `pak::pak(...)` call made before Require is loaded (e.g. the first line of a
-  bootstrap script) is outside Require's reach -- set `R_BIOC_VERSION` yourself
-  there, or in `.Rprofile`.
+  bioc.org is unreachable (network blip, firewall, bioc downtime) -- even when no
+  Bioconductor package was requested. This is **failure-triggered**: pak calls
+  run normally (so the real, current Bioc config is used whenever bioc.org is
+  reachable), and *only* when a call dies on that specific fetch does `pakCall()`
+  point pkgcache at its own bundled bioc config (`R_BIOC_CONFIG_URL` file:// +
+  `R_BIOC_VERSION`, set only when unset) and retry once. We deliberately do **not**
+  pin the Bioc config pre-emptively -- doing so would freeze the Bioc version
+  (to pkgcache's snapshot) for every user, including those who never hit the
+  failure and who actually use Bioconductor. The underlying hard-fail is a pak
+  bug (an optional config fetch should not abort the whole operation); this is a
+  local fallback until that is fixed upstream. Note: a *direct* `pak::pak(...)`
+  call made before Require is loaded (e.g. a bootstrap script's first line) is
+  outside Require's reach -- set `R_BIOC_VERSION` yourself there or in `.Rprofile`.
 
 # Require 2.0.0.9031 (development version)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# Require 2.0.0.9032 (development version)
+
+* Resilience to the transient
+  `cannot open URL 'http://bioconductor.org/config.yaml'` failure. pak/pkgcache
+  fetch the Bioconductor config at startup, and the entire pak call dies when
+  bioc.org is unreachable (network blip, firewall, bioc downtime). Require now
+  points pak at pkgcache's own bundled bioc config (`R_BIOC_CONFIG_URL` file://)
+  and pins `R_BIOC_VERSION` so it never reaches the network -- set at load and
+  before every Require pak call, only when unset (respects a user's explicit
+  values) and only when the bundled fixture is found. Note: a *direct*
+  `pak::pak(...)` call made before Require is loaded (e.g. the first line of a
+  bootstrap script) is outside Require's reach -- set `R_BIOC_VERSION` yourself
+  there, or in `.Rprofile`.
+
 # Require 2.0.0.9031 (development version)
 
 * `Require()`/`Install()` now warn to restart R when a package is installed at a

--- a/R/pak.R
+++ b/R/pak.R
@@ -61,7 +61,57 @@ regexEscape <- function(x) {
   FALSE
 }
 
+# Locate pkgcache's bundled `bioc-config.yaml` fixture and its release_version.
+# pak/pkgcache fetch http://bioconductor.org/config.yaml at startup to detect the
+# Bioconductor version; when bioc.org is unreachable (network blip, firewall, bioc
+# downtime) the ENTIRE pak call dies with
+#   `cannot open URL 'http://bioconductor.org/config.yaml'`.
+# Returns list(version=<chr or NA>, path=<chr or "">). pkgcache usually lives inside
+# pak's private library, so the top-level system.file() returns "" -- fall back to
+# pak's library/.
+pakBiocFixture <- function() {
+  fixture <- tryCatch(system.file("fixtures", "bioc-config.yaml", package = "pkgcache"),
+                      error = function(e) "")
+  if (!nzchar(fixture)) {
+    pakDir <- tryCatch(find.package("pak"), error = function(e) "")
+    if (length(pakDir) && nzchar(pakDir)) {
+      cand <- file.path(pakDir, "library", "pkgcache", "fixtures", "bioc-config.yaml")
+      if (file.exists(cand)) fixture <- cand
+    }
+  }
+  version <- NA_character_
+  if (nzchar(fixture) && file.exists(fixture)) {
+    relLine <- grep("^release_version:", readLines(fixture, warn = FALSE), value = TRUE)[1L]
+    v <- sub('^release_version:\\s*"?([^"\\s]+)"?\\s*$', "\\1", relLine, perl = TRUE)
+    if (length(v) && nzchar(v) && !is.na(v)) version <- v
+  }
+  list(version = version, path = fixture)
+}
+
+# Point pak/pkgcache at the bundled bioc config so it NEVER reaches
+# bioconductor.org. Sets R_BIOC_VERSION + R_BIOC_CONFIG_URL, but ONLY when they
+# are unset (respecting a user's explicit choice) AND only when the bundled
+# fixture is actually found (so we set the correct version + a working file://
+# URL rather than guessing). Idempotent and cheap -- safe to call on every pak
+# call. Persistent (no on.exit restore): the goal is session-wide resilience to
+# the transient bioc fetch failure.
+setBiocConfigEnvForPak <- function() {
+  haveVer <- nzchar(Sys.getenv("R_BIOC_VERSION"))
+  haveUrl <- nzchar(Sys.getenv("R_BIOC_CONFIG_URL"))
+  if (haveVer && haveUrl) return(invisible(FALSE))
+  bf <- pakBiocFixture()
+  if (is.na(bf$version) || !nzchar(bf$path) || !file.exists(bf$path))
+    return(invisible(FALSE))   # no fixture -> don't guess a (possibly wrong) version
+  if (!haveVer) Sys.setenv(R_BIOC_VERSION = bf$version)
+  if (!haveUrl)
+    Sys.setenv(R_BIOC_CONFIG_URL = paste0("file://", normalizePath(bf$path, winslash = "/")))
+  invisible(TRUE)
+}
+
 pakCall <- function(expr, verbose = getOption("Require.verbose")) {
+  ## Resilience: stop pak/pkgcache reaching bioconductor.org/config.yaml on every
+  ## call (it kills the whole call when bioc.org is unreachable). Idempotent.
+  setBiocConfigEnvForPak()
   ## Inline null-coalesce: `%||%` is base in R 4.4+ but not 4.3, and Require
   ## doesn't import it from rlang. Without this, pakCall errors on R 4.3
   ## (silently, since try() in callers swallows it), turning every pak
@@ -1150,26 +1200,12 @@ pakOfflineInstall <- function(pkgDT, libPaths, verbose = getOption("Require.verb
                    paste(pkgsToInstall, collapse = ", "),
                    verbose = verbose, verboseLevel = 1)
 
-    ## Locate pkgcache's bioc-config.yaml fixture. pkgcache lives inside
-    ## pak's private library on most installs, so the top-level
-    ## system.file() lookup returns "" -- fall back to pak's library/.
-    biocFixture <- tryCatch(
-      system.file("fixtures", "bioc-config.yaml", package = "pkgcache"),
-      error = function(e) "")
-    if (!nzchar(biocFixture)) {
-      pakDir <- tryCatch(find.package("pak"), error = function(e) "")
-      if (length(pakDir) && nzchar(pakDir)) {
-        cand <- file.path(pakDir, "library", "pkgcache", "fixtures",
-                          "bioc-config.yaml")
-        if (file.exists(cand)) biocFixture <- cand
-      }
-    }
-    biocVer <- if (nzchar(biocFixture) && file.exists(biocFixture)) {
-      relLine <- grep("^release_version:", readLines(biocFixture, warn = FALSE),
-                      value = TRUE)[1L]
-      v <- sub('^release_version:\\s*"?([^"\\s]+)"?\\s*$', "\\1", relLine, perl = TRUE)
-      if (length(v) && nzchar(v) && !is.na(v)) v else "3.22"
-    } else "3.22"
+    ## Locate pkgcache's bioc-config.yaml fixture (shared helper). Fall back to
+    ## "3.22" only here (the offline path needs *some* version even if pak's
+    ## fixture can't be found, since it must avoid the network entirely).
+    .bf <- pakBiocFixture()
+    biocFixture <- .bf$path
+    biocVer <- if (!is.na(.bf$version)) .bf$version else "3.22"
     envNms <- c("R_BIOC_VERSION", "R_BIOC_CONFIG_URL",
                 "PKG_METADATA_UPDATE_AFTER")
     oldEnv <- Sys.getenv(envNms, names = TRUE, unset = NA)

--- a/R/pak.R
+++ b/R/pak.R
@@ -108,10 +108,32 @@ setBiocConfigEnvForPak <- function() {
   invisible(TRUE)
 }
 
+# TRUE iff an error (walking its `parent` cause chain) is pak/pkgcache failing to
+# fetch bioconductor.org/config.yaml. pak fetches that at startup to detect the
+# Bioc version and hard-fails the WHOLE call when bioc.org is unreachable, even
+# when no Bioconductor package was requested. Used by pakCall() to trigger the
+# one-shot bundled-config fallback.
+isBiocConfigFetchError <- function(e) {
+  if (is.null(e)) return(FALSE)
+  txt <- character(0)
+  cur <- e
+  depth <- 0L
+  while (!is.null(cur) && depth < 10L) {
+    txt <- c(txt, tryCatch(conditionMessage(cur), error = function(x) ""))
+    cur <- cur$parent
+    depth <- depth + 1L
+  }
+  txt <- paste(txt, collapse = "\n")
+  grepl("bioconductor\\.org/config\\.yaml", txt, ignore.case = TRUE) ||
+    (grepl("config\\.yaml", txt, ignore.case = TRUE) &&
+       grepl("bioconductor", txt, ignore.case = TRUE))
+}
+
 pakCall <- function(expr, verbose = getOption("Require.verbose")) {
-  ## Resilience: stop pak/pkgcache reaching bioconductor.org/config.yaml on every
-  ## call (it kills the whole call when bioc.org is unreachable). Idempotent.
-  setBiocConfigEnvForPak()
+  ## Capture the pak call UNEVALUATED so we can re-run it if the first attempt
+  ## dies on the bioconductor.org/config.yaml fetch (see runWithBiocFallback).
+  exprSub <- substitute(expr)
+  pf <- parent.frame()
   ## Inline null-coalesce: `%||%` is base in R 4.4+ but not 4.3, and Require
   ## doesn't import it from rlang. Without this, pakCall errors on R 4.3
   ## (silently, since try() in callers swallows it), turning every pak
@@ -130,18 +152,38 @@ pakCall <- function(expr, verbose = getOption("Require.verbose")) {
     Sys.setenv(PKG_SYSREQS = "false", PKG_SYSREQS_SUDO = "false")
     options(pkg.sysreqs = FALSE, pkg.sysreqs_sudo = FALSE)
   }
+  ## Failure-triggered bioc resilience: run the pak call normally (so when
+  ## bioc.org is reachable, pak uses the real, current Bioconductor config). ONLY
+  ## if it dies on the bioc config fetch, point pkgcache at its bundled config
+  ## (no network) and retry ONCE. We never pre-empt the fetch globally, so we
+  ## don't freeze the Bioc version for users who don't hit the failure.
+  runWithBiocFallback <- function() {
+    tryCatch(
+      eval(exprSub, envir = pf),
+      error = function(e) {
+        if (isBiocConfigFetchError(e) && setBiocConfigEnvForPak()) {
+          messageVerbose(
+            "pak could not reach bioconductor.org/config.yaml; retrying with ",
+            "pkgcache's bundled Bioconductor config (offline, no network).",
+            verbose = verbose, verboseLevel = 1)
+          eval(exprSub, envir = pf)
+        } else {
+          stop(e)
+        }
+      })
+  }
   if (verbose <= -1L) {
     old <- options(pkg.show_progress = FALSE)
     on.exit(options(old), add = TRUE)
     .res <- NULL
-    utils::capture.output(.res <- suppressMessages(force(expr)), type = "output")
+    utils::capture.output(.res <- suppressMessages(runWithBiocFallback()), type = "output")
     .res
   } else if (verbose == 0L) {
     old <- options(pkg.show_progress = FALSE)
     on.exit(options(old), add = TRUE)
-    force(expr)
+    runWithBiocFallback()
   } else {
-    force(expr)
+    runWithBiocFallback()
   }
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -58,6 +58,15 @@ envPkgCreate()
       options(pkg.sysreqs_sudo = FALSE)
   }
 
+  ## Resilience against the transient
+  ##   `cannot open URL 'http://bioconductor.org/config.yaml'`
+  ## failure: pak/pkgcache fetch the Bioconductor config at startup and the whole
+  ## pak call dies when bioc.org is unreachable. Point pkgcache at its own bundled
+  ## config (file://) + pin the version so it never hits the network. Only sets
+  ## the env vars when unset and when the bundled fixture is found (no-op if pak
+  ## isn't installed yet at load time; pakCall() re-attempts once pak is present).
+  setBiocConfigEnvForPak()
+
   ## DELIBERATELY do NOT eagerly load pak here. Loading pak grabs a Windows
   ## DLL lock that prevents `ensurePakInProjectLib()` from later reinstalling
   ## pak in libPaths[1] when needed (e.g. when pak is missing from the

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -58,14 +58,15 @@ envPkgCreate()
       options(pkg.sysreqs_sudo = FALSE)
   }
 
-  ## Resilience against the transient
-  ##   `cannot open URL 'http://bioconductor.org/config.yaml'`
-  ## failure: pak/pkgcache fetch the Bioconductor config at startup and the whole
-  ## pak call dies when bioc.org is unreachable. Point pkgcache at its own bundled
-  ## config (file://) + pin the version so it never hits the network. Only sets
-  ## the env vars when unset and when the bundled fixture is found (no-op if pak
-  ## isn't installed yet at load time; pakCall() re-attempts once pak is present).
-  setBiocConfigEnvForPak()
+  ## NOTE: we deliberately do NOT pre-emptively pin the Bioconductor config here.
+  ## pak/pkgcache fetch bioconductor.org/config.yaml at startup, and the whole
+  ## pak call dies when bioc.org is unreachable -- but globally pinning
+  ## R_BIOC_VERSION to pkgcache's bundled (snapshot) config would silently freeze
+  ## the Bioc version for *every* Require user, even those who never hit the
+  ## fetch failure and who actually use Bioconductor. Instead, pakCall() catches
+  ## that specific fetch error and retries ONCE with the bundled config -- so the
+  ## real, current Bioc config is used whenever bioc.org is reachable, and the
+  ## fallback kicks in only when it genuinely fails. See pakCall() / setBiocConfigEnvForPak().
 
   ## DELIBERATELY do NOT eagerly load pak here. Loading pak grabs a Windows
   ## DLL lock that prevents `ensurePakInProjectLib()` from later reinstalling

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1914,3 +1914,54 @@ test_that("setBiocConfigEnvForPak uses bundled bioc config, idempotent, respects
   Require:::setBiocConfigEnvForPak()
   testthat::expect_identical(Sys.getenv("R_BIOC_VERSION"), "9.9")
 })
+
+# ---------------------------------------------------------------------------
+# The bioc-config resilience is FAILURE-TRIGGERED: pakCall() runs the pak call
+# normally (so the real Bioc config is used when bioc.org is reachable) and only
+# falls back to the bundled config + retries once when the call dies on the bioc
+# fetch. It must NOT pin the Bioc config pre-emptively on success.
+# ---------------------------------------------------------------------------
+test_that("isBiocConfigFetchError detects the bioc fetch error via the cause chain", {
+  e <- simpleError("error in pak subprocess")
+  e$parent <- simpleError("cannot open URL 'http://bioconductor.org/config.yaml'")
+  testthat::expect_true(Require:::isBiocConfigFetchError(e))
+  testthat::expect_false(Require:::isBiocConfigFetchError(simpleError("Could not solve package dependencies")))
+  testthat::expect_false(Require:::isBiocConfigFetchError(NULL))
+})
+
+test_that("pakCall is failure-triggered: no proactive pin on success; retries once on bioc error", {
+  old <- Sys.getenv(c("R_BIOC_VERSION", "R_BIOC_CONFIG_URL"), names = TRUE, unset = NA)
+  on.exit({
+    for (nm in names(old))
+      if (is.na(old[[nm]])) Sys.unsetenv(nm) else do.call(Sys.setenv, setNames(list(old[[nm]]), nm))
+  }, add = TRUE)
+
+  # success path must not set the bioc env
+  Sys.unsetenv("R_BIOC_VERSION"); Sys.unsetenv("R_BIOC_CONFIG_URL")
+  testthat::expect_identical(Require:::pakCall("ok", verbose = 0), "ok")
+  testthat::expect_false(nzchar(Sys.getenv("R_BIOC_VERSION")))
+
+  # bioc fetch error -> fall back + retry once
+  bf <- Require:::pakBiocFixture()
+  testthat::skip_if(is.na(bf$version) || !nzchar(bf$path), "pkgcache bioc fixture not found")
+  Sys.unsetenv("R_BIOC_VERSION"); Sys.unsetenv("R_BIOC_CONFIG_URL")
+  n <- 0L
+  f <- function() {
+    n <<- n + 1L
+    if (n == 1L) {
+      e <- simpleError("error in pak subprocess")
+      e$parent <- simpleError("cannot open URL 'http://bioconductor.org/config.yaml'")
+      stop(e)
+    }
+    "retried"
+  }
+  testthat::expect_identical(Require:::pakCall(f(), verbose = 0), "retried")
+  testthat::expect_identical(n, 2L)                              # exactly one retry
+  testthat::expect_true(nzchar(Sys.getenv("R_BIOC_VERSION")))    # env set only on fallback
+
+  # a non-bioc error propagates without retry
+  m <- 0L
+  g <- function() { m <<- m + 1L; stop("Could not solve package dependencies") }
+  testthat::expect_error(Require:::pakCall(g(), verbose = 0), "solve package")
+  testthat::expect_identical(m, 1L)
+})

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1886,3 +1886,31 @@ test_that("flagRestartForLoadedInsufficient flags loaded-but-insufficient, leave
   testthat::expect_identical(
     Require:::flagRestartForLoadedInsufficient(d4)$installResult, "OK")
 })
+
+# ---------------------------------------------------------------------------
+# Resilience to the transient `cannot open URL 'http://bioconductor.org/config.yaml'`
+# failure: setBiocConfigEnvForPak() points pak/pkgcache at its own bundled bioc
+# config (file://) and pins R_BIOC_VERSION, so pak never reaches bioc.org. Only
+# sets unset env vars (respects the user), only when the bundled fixture exists.
+# ---------------------------------------------------------------------------
+test_that("setBiocConfigEnvForPak uses bundled bioc config, idempotent, respects user", {
+  skip_if_not_installed("pak")
+  old <- Sys.getenv(c("R_BIOC_VERSION", "R_BIOC_CONFIG_URL"), names = TRUE, unset = NA)
+  on.exit({
+    for (nm in names(old))
+      if (is.na(old[[nm]])) Sys.unsetenv(nm) else do.call(Sys.setenv, setNames(list(old[[nm]]), nm))
+  }, add = TRUE)
+
+  Sys.unsetenv("R_BIOC_VERSION"); Sys.unsetenv("R_BIOC_CONFIG_URL")
+  bf <- Require:::pakBiocFixture()
+  testthat::skip_if(is.na(bf$version) || !nzchar(bf$path), "pkgcache bioc fixture not found")
+
+  testthat::expect_true(Require:::setBiocConfigEnvForPak())                 # sets
+  testthat::expect_true(nzchar(Sys.getenv("R_BIOC_VERSION")))
+  testthat::expect_match(Sys.getenv("R_BIOC_CONFIG_URL"), "^file://")
+  testthat::expect_false(Require:::setBiocConfigEnvForPak())                # idempotent
+
+  Sys.setenv(R_BIOC_VERSION = "9.9", R_BIOC_CONFIG_URL = "file:///x")       # explicit user values
+  Require:::setBiocConfigEnvForPak()
+  testthat::expect_identical(Sys.getenv("R_BIOC_VERSION"), "9.9")
+})


### PR DESCRIPTION
## Symptom
```
Error: ! error in pak subprocess
Caused by error in `download.file(url, tmp, quiet = TRUE)`:
! cannot open URL 'http://bioconductor.org/config.yaml'
```
pak/pkgcache fetch the Bioconductor config at startup (pak always includes Bioc), and the **whole pak call dies** when bioc.org is unreachable — even when no Bioconductor package was requested.

## Why this is failure-triggered (not proactive)
An earlier cut pinned `R_BIOC_VERSION` + `R_BIOC_CONFIG_URL` (→ pkgcache's bundled config) at load and before every pak call. That stops the failure, but **globally freezes the Bioc version to pkgcache's shipped snapshot for every Require user** — including those who never hit the failure and who actually use Bioconductor. Require is a general CRAN package, so that's a bad trade (loud transient error → quiet permanent inaccuracy). The underlying hard-fail is really a **pak bug** (an optional config fetch shouldn't abort the whole operation).

So instead:
- `pakCall()` runs the pak call **normally** — when bioc.org is reachable, pak uses the real, current Bioc config.
- New `isBiocConfigFetchError()` walks the error's `parent` cause chain for the config.yaml fetch failure.
- **Only** on that error does `pakCall()` point pkgcache at its bundled config (`R_BIOC_CONFIG_URL` file:// + `R_BIOC_VERSION`, set only when unset) and **retry once**.
- Non-bioc errors propagate unchanged; a successful call never pins anything.

`pakCall()` now captures its argument unevaluated (`substitute`/`eval`) so the retry can re-run the same call.

## Scope / known limit
A **direct** `pak::pak(...)` issued *before Require is loaded* (e.g. a bootstrap `global.R`'s first line) is outside Require's reach — set `R_BIOC_VERSION` there or in `.Rprofile`. Worth an upstream pak issue for graceful degradation.

Tests: `isBiocConfigFetchError` detection; `pakCall` no-proactive-pin on success, one-shot retry on the bioc error, non-bioc error propagation. Version `2.0.0.9032`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)