### PR TITLE
fix(getCRANrepos): preserve other repos (e.g. r-universe) when resolving @CRAN@

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9031
+Version: 2.0.0.9033
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# Require 2.0.0.9033 (development version)
+
+* `getCRANrepos()` no longer drops other repositories when resolving the
+  `"@CRAN@"` placeholder. Previously, when `repos` contained `"@CRAN@"` **and**
+  the `CRAN_REPO` env var was set (RStudio's default state: `repos` is
+  `c(CRAN = "@CRAN@")` and RStudio sets `CRAN_REPO`), it replaced the entire
+  `repos` vector with CRAN-only — silently wiping an r-universe a user had added
+  via `options(repos = unique(c(<r-universe>, getOption("repos"))))`. That broke
+  `Require.noRemotes` installs of PredictiveEcology packages (LandR, pemisc, ...)
+  for RStudio users: the packages "could not be found" because their hosting
+  r-universe had been removed from `repos` mid-run. Now the `"@CRAN@"`
+  placeholder is resolved in place and every other repo is preserved.
+
 # Require 2.0.0.9031 (development version)
 
 * `Require()`/`Install()` now warn to restart R when a package is installed at a

--- a/R/CRAN.R
+++ b/R/CRAN.R
@@ -24,7 +24,18 @@ getCRANrepos <- function(repos = NULL, ind) {
   if (isTRUE("@CRAN@" %in% repos)) {
     cranRepo <- Sys.getenv("CRAN_REPO")
     repos <- if (nzchar(cranRepo)) {
-      options("repos" = c("CRAN" = cranRepo))
+      # Resolve the "@CRAN@" placeholder(s) to `cranRepo` IN PLACE, preserving
+      # every other configured repo. The previous
+      # `options("repos" = c("CRAN" = cranRepo))` REPLACED the whole repos vector
+      # with CRAN-only, silently dropping an r-universe (e.g. RStudio's default
+      # repos is `c(CRAN = "@CRAN@")` and RStudio sets `CRAN_REPO`, so an
+      # `options(repos = unique(c(<r-universe>, getOption("repos"))))` set by the
+      # user was wiped here). That broke `Require.noRemotes` installs, which
+      # resolve PredictiveEcology packages from that r-universe. Mirrors the
+      # `reposNow[!hasAts]` handling below (which already preserves other repos).
+      reposNow <- getOption("repos")
+      reposNow[reposNow %in% "@CRAN@"] <- cranRepo
+      options(repos = reposNow)
       cranRepo
     } else {
       if (isInteractive() && missing(ind)) {

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1886,3 +1886,32 @@ test_that("flagRestartForLoadedInsufficient flags loaded-but-insufficient, leave
   testthat::expect_identical(
     Require:::flagRestartForLoadedInsufficient(d4)$installResult, "OK")
 })
+
+# ---------------------------------------------------------------------------
+# getCRANrepos must resolve the "@CRAN@" placeholder IN PLACE, preserving other
+# repos (e.g. an r-universe). Regression: previously, when "@CRAN@" was present
+# AND CRAN_REPO was set (RStudio's default state), it replaced the entire repos
+# vector with CRAN-only, silently dropping r-universe and breaking
+# Require.noRemotes installs of PredictiveEcology packages.
+# ---------------------------------------------------------------------------
+test_that("getCRANrepos preserves non-CRAN repos when resolving @CRAN@", {
+  oldRepos <- getOption("repos"); oldEnv <- Sys.getenv("CRAN_REPO", unset = NA)
+  on.exit({
+    options(repos = oldRepos)
+    if (is.na(oldEnv)) Sys.unsetenv("CRAN_REPO") else Sys.setenv(CRAN_REPO = oldEnv)
+  }, add = TRUE)
+
+  peUniv <- "https://predictiveecology.r-universe.dev"
+
+  # GEDET5 case: r-universe + an unnamed "@CRAN@" + CRAN_REPO set
+  Sys.setenv(CRAN_REPO = "https://cran.rstudio.com/")
+  options(repos = c(CRAN = "https://cloud.r-project.org", peUniv, "@CRAN@"))
+  invisible(getCRANrepos(ind = 1))
+  testthat::expect_true(any(peUniv == unname(getOption("repos"))))   # r-universe kept
+  testthat::expect_false(any("@CRAN@" == unname(getOption("repos")))) # placeholder resolved
+
+  # no @CRAN@ -> untouched
+  options(repos = c(CRAN = "https://cloud.r-project.org", peUniv))
+  invisible(getCRANrepos(ind = 1))
+  testthat::expect_true(any(peUniv == unname(getOption("repos"))))
+})


### PR DESCRIPTION
## Root cause (the "other place" resetting repos)
A workshop participant on **RStudio** running the same `global.R` as the maintainer kept failing under `Require.noRemotes` — LandR/pemisc/scfmutils/LandR.CS "could not be found", `simInit` died with *"no package named 'LandR'"* — and her `options("repos")` showed only `cran.rstudio.com` despite her script setting r-universe.

`getCRANrepos()` is the culprit (distinct from the SpaDES.project #111 unnamed-repos fix):

```r
if (isTRUE("@CRAN@" %in% repos)) {
  cranRepo <- Sys.getenv("CRAN_REPO")
  repos <- if (nzchar(cranRepo)) {
    options("repos" = c("CRAN" = cranRepo))   # <-- replaces ENTIRE repos with CRAN-only
```

RStudio's default `options(repos)` is `c(CRAN = "@CRAN@")` and RStudio sets `CRAN_REPO` (e.g. `https://cran.rstudio.com/`). So for any RStudio user who added an r-universe via `options(repos = unique(c(<r-universe>, getOption("repos"))))`, the moment `getCRANrepos()` ran during install it **wiped r-universe**, leaving CRAN-only — exactly her observed `cran.rstudio.com`. `noRemotes` then couldn't resolve the PE packages (they live on that r-universe). Never reproduced on the maintainer's machine because `CRAN_REPO` wasn't set there.

## Fix
Resolve the `"@CRAN@"` placeholder(s) **in place** and preserve every other repo — mirroring the `reposNow[!hasAts]` handling a few lines below (which already does the right thing for the non-`CRAN_REPO` branch).

Verified across cases (r-universe survives; `@CRAN@` resolved; no-`@CRAN@` untouched). Regression test added. Bump `2.0.0.9031` → `2.0.0.9033` (`.9032` is the open bioc PR #174).

🤖 Generated with [Claude Code](https://claude.com/claude-code)