### PR TITLE
fix(noRemotes): strip GitHub refs at the pak resolver entry so Remotes are never followed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL:
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
 Date: 2026-06-06
-Version: 2.0.0.9034
+Version: 2.0.0.9036
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# Require 2.0.0.9036 (development version)
+
+* `Require.noRemotes = TRUE` now reliably follows **no** `Remotes:`. pak follows a
+  package's `Remotes:` field whenever it resolves that package from a GitHub /
+  source ref (pkgdepends' `resolve_from_description` → `resolve_ref_deps`
+  rewrites a dependency's ref to the matching `Remotes` entry, e.g.
+  `LandR` → `PredictiveEcology/LandR`) — there is no pkgdepends switch to turn
+  this off. A package resolved from a repository is immune (r-universe's
+  `PACKAGES` has no `Remotes` column). So under noRemotes the guarantee is simply
+  that no `account/repo[@ref]` ref reaches pak's resolver. `pakDepsToPkgDT()` now
+  re-applies `stripGitHubToRepos()` at its entry (in addition to the top-level
+  strip in `Require()`), so a GitHub ref can't slip through any caller/path and
+  cause a transitive dependency (e.g. `LandR` pulled by `LandR.CS`'s `Remotes`)
+  to be built from GitHub source instead of resolved from the configured repos.
+
 # Require 2.0.0.9034 (development version)
 
 * Resilience to the transient

--- a/R/pak.R
+++ b/R/pak.R
@@ -2295,6 +2295,22 @@ pakDepsToPkgDT <- function(packages, which, libPaths, standAlone, verbose,
          conditionMessage(pakLoad), ")", call. = FALSE)
   }
 
+  # Defense-in-depth for Require.noRemotes: ensure NO GitHub ref reaches pak's
+  # resolver. pak follows a package's `Remotes:` field ONLY when it resolves that
+  # package from a GitHub/source ref (pkgdepends' resolve_from_description scans
+  # the DESCRIPTION and resolve_ref_deps UNCONDITIONALLY rewrites a dependency's
+  # ref to the matching Remotes entry, e.g. `LandR` -> `PredictiveEcology/LandR`).
+  # A bare repo ref is immune -- r-universe's PACKAGES carries no `Remotes`
+  # column, so a bare `LandR.CS` resolves `LandR` as a `standard` repo ref. There
+  # is no pkgdepends toggle to disable Remotes-following, so the only guarantee
+  # that noRemotes means "resolve from repos, follow no Remotes" is to ensure no
+  # `account/repo[@ref]` ref reaches this resolver. The top-level strip in
+  # Require() (stripGitHubToRepos) normally does this; re-apply it here so it
+  # holds for ANY caller/path into pakDepsToPkgDT. No-op (and silent) once the
+  # refs are already bare.
+  if (isTRUE(getOption("Require.noRemotes", FALSE)))
+    packages <- stripGitHubToRepos(packages, verbose = verbose)
+
   # Honour an explicit type = "source": pin pak to source-only resolution for
   # the duration of this call (covers the nested pakDepsResolve/pak::pkg_deps).
   oldPlatforms <- forcePakSourceIfRequested(type)


### PR DESCRIPTION
## The noRemotes ⟹ "don't follow Remotes" guarantee

Under `Require.noRemotes = TRUE` (Linux, R 4.6), `LandR` was built from **GitHub** despite noRemotes:
```
✔ Installed LandR 1.2.0.9002 (github::PredictiveEcology/LandR@f9d7d39)
```

### Where it goes wrong (verified against pkgdepends)
pak follows a package's `Remotes:` field **only** when it resolves that package from a **GitHub/source** ref:
- `resolve_from_description()` scans the DESCRIPTION, and `resolve_ref_deps()` **unconditionally** rewrites a dependency's ref to the matching `Remotes` entry (`LandR` → `PredictiveEcology/LandR`).
- A package resolved from a **repository** is immune — r-universe's `PACKAGES` has **no `Remotes` column**, and I confirmed `pak::pkg_deps("LandR.CS")` (bare) resolves `LandR` as a `standard` repo ref.
- There is **no pkgdepends switch** to disable Remotes-following.

So the only way to guarantee noRemotes means *"resolve from repos, follow no Remotes"* is to ensure **no `account/repo[@ref]` ref reaches pak's resolver**. When one does (so pak scans its DESCRIPTION), its `Remotes` get followed and a dependency is pulled from GitHub source — which is what happened to `LandR` (pulled by `LandR.CS`'s `Remotes`).

### Fix
`pakDepsToPkgDT()` re-applies `stripGitHubToRepos()` at its entry, in addition to the existing top-level strip in `Require()`. This makes the strip airtight for **any** caller/path into the resolver. It's a no-op (and silent) once refs are already bare.

Bump `2.0.0.9034` → `2.0.0.9036` (`.9035` is the open PR #176).

> Complements #176: #176 makes the *deferred install* complete even when ordering is off; this PR removes the GitHub detour at the root so `LandR`/`LandR.CS` resolve from r-universe under noRemotes in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)