### PR TITLE
ci: bump actions/checkout v4 -> v5 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,7 +58,7 @@ jobs:
       R_REQUIRE_RUN_LONG_CI: ${{ matrix.config.runLong && 'true' || '' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # setup-pandoc occasionally fails with HTTP 5xx when its CDN blips
       # (hit SpaDES.tools today). Three attempts with continue-on-error

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,7 +23,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
GitHub deprecated Node 20 and force-runs `actions/checkout@v4` on Node 24. Bump to `@v5` in R-CMD-check / pkgdown / test-coverage.

Require keeps its standalone workflows rather than migrating to the shared reusable
workflows: it is pure-R with a deliberately broad old-R matrix (windows down to
oldrel-2 / R 4.3, ubuntu down to oldrel-3 / R 4.2, plus a runLong leg) and runs no
donttest, so the geospatial reusable workflow is not a fit. `rhub.yaml` uses
`r-hub/actions/checkout@v1` and is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)