### PR TITLE
fix: warn, not message, when a snapshot's R version differs from the session

### DIFF
--- a/R/Require2.R
+++ b/R/Require2.R
@@ -1770,11 +1770,20 @@ doPkgSnapshot <- function(packageVersionFile, purge, libPaths,
     if (packages[1, "Package"] == "R") {
       Rversion <- packages[["Version"]][1] |> versionMajorMinor()
       if (!compareVersion2(versionMajorMinor(), Rversion, inequality = "=="))
-        messageVerbose("The package snapshot was made using R ", Rversion,
-                       ". Current session is running R ", getRversion(),
-                       "\nThere may be difficulties installing packages. ",
-                       "If there are please restart session using the appropriate R version",
-                       verbose = verbose)
+        ## warning(), not messageVerbose(): a snapshot pinned under a different
+        ## R routinely fails to build -- packages pinned under an older R can
+        ## use headers or functions the current one has removed (e.g. Calloc /
+        ## Free before STRICT_R_HEADERS, is.R() now defunct) -- and the symptom
+        ## is hundreds of lines of compiler output with no statement of the
+        ## cause. A message at a verbosity level is suppressed by default in
+        ## quiet sessions and swallowed entirely under testthat, so the one
+        ## piece of information that explains the failure was the piece most
+        ## likely to be lost.
+        warning("The package snapshot was made using R ", Rversion,
+                ". Current session is running R ", getRversion(),
+                ". There may be difficulties installing packages; ",
+                "if there are, please restart the session using R ", Rversion,
+                call. = FALSE)
       packages <- packages[-1, ]
     }
 

--- a/tests/testthat/test-23snapshotRversion_testthat.R
+++ b/tests/testthat/test-23snapshotRversion_testthat.R
@@ -1,0 +1,74 @@
+## A snapshot records the R version it was taken under, in a leading "R" row.
+## Installing it under a different R routinely fails to build -- pins made
+## under an older R can use headers or functions the current one has removed
+## (Calloc / Free before STRICT_R_HEADERS, is.R() now defunct) -- and the
+## symptom is hundreds of lines of compiler output that never say why.
+##
+## This was a messageVerbose(), so it was suppressed in quiet sessions and
+## swallowed under testthat: the one piece of information that explained the
+## failure was the piece most likely to be lost. These pin it as a warning.
+
+snapshotFileWithRversion <- function(rver, dir = withr::local_tempdir(.local_envir = parent.frame())) {
+  f <- file.path(dir, "pkgSnapshot.txt")
+  data.table::fwrite(
+    data.table::data.table(
+      Package = c("R", "aaaNotARealPackage"),
+      Version = c(rver, "1.0.0")
+    ), file = f)
+  f
+}
+
+test_that("a snapshot from a different R version warns", {
+  otherR <- if (getRversion() >= "4.5") "4.4" else "4.6"
+  f <- snapshotFileWithRversion(otherR)
+
+  expect_warning(
+    try(suppressMessages(
+      Require::Require(packageVersionFile = f, require = FALSE, standAlone = TRUE)
+    ), silent = TRUE),
+    "snapshot was made using R"
+  )
+})
+
+test_that("the warning names both R versions", {
+  otherR <- if (getRversion() >= "4.5") "4.4" else "4.6"
+  f <- snapshotFileWithRversion(otherR)
+
+  w <- tryCatch({
+    try(suppressMessages(
+      Require::Require(packageVersionFile = f, require = FALSE, standAlone = TRUE)
+    ), silent = TRUE)
+    character()
+  }, warning = function(x) conditionMessage(x))
+
+  expect_match(w, otherR, fixed = TRUE)
+  expect_match(w, as.character(getRversion()), fixed = TRUE)
+})
+
+test_that("the R-version warning survives a silent verbosity setting", {
+  ## the regression: as a messageVerbose() this vanished at low verbose, which
+  ## is the default in many sessions and always the case under testthat
+  otherR <- if (getRversion() >= "4.5") "4.4" else "4.6"
+  f <- snapshotFileWithRversion(otherR)
+
+  withr::local_options(Require.verbose = -2)
+
+  expect_warning(
+    try(suppressMessages(
+      Require::Require(packageVersionFile = f, require = FALSE, standAlone = TRUE)
+    ), silent = TRUE),
+    "snapshot was made using R"
+  )
+})
+
+test_that("a snapshot from the running R version does not warn about R", {
+  f <- snapshotFileWithRversion(Require:::versionMajorMinor())
+
+  ws <- testthat::capture_warnings(
+    try(suppressMessages(
+      Require::Require(packageVersionFile = f, require = FALSE, standAlone = TRUE)
+    ), silent = TRUE)
+  )
+
+  expect_false(any(grepl("snapshot was made using R", ws)))
+})


### PR DESCRIPTION
A snapshot records the R version it was taken under, in a leading `R` row. `doPkgSnapshot()` already compared that against the running R -- but reported the mismatch with `messageVerbose()`.

That is suppressed in quiet sessions (`Require.verbose` below the threshold) and swallowed entirely under testthat. So the one piece of information that explains the failure was the piece most likely to be lost.

## The failure it explains

A snapshot pinned under an older R routinely will not build: those pins use headers or functions the current R has removed.

```
* installing *source* package ‘bit’ ...
bit.c:2818:11: warning: implicit declaration of function ‘Calloc’
bit.c:2818:22: error: expected expression before ‘int’
make: *** [bit.o] Error 1
ERROR: compilation failed for package ‘bit’

* installing *source* package ‘bdsmatrix’ ...
Error in is.R() : 'is.R' is defunct.
ERROR: lazy loading failed for package ‘bdsmatrix’
```

`Calloc`/`Free` went behind `STRICT_R_HEADERS`; `is.R()` is defunct. What the user sees is hundreds of lines of compiler output with nothing stating the cause.

Observed exactly that installing `inst/snapshot.txt` -- taken under R 4.4 -- on R 4.5.3. The snapshot was not stale; it was run under the wrong R, and nothing said so.

## Change

`messageVerbose()` -> `warning()`, so it survives verbosity settings and test harnesses. No change to the comparison logic.

## Tests

`test-23snapshotRversion_testthat.R`, 5 assertions, no installs:

- warns on a mismatch
- names both R versions
- **survives `Require.verbose = -2`** -- the regression
- does not warn when the versions agree

Verified against the old code: 4 of the 5 fail as a `messageVerbose()`.

## Note

`inst/snapshot.txt` is **not** being regenerated here. Its `R` row says 4.4, which is correct for a 4.4 session; it only misbehaves when run under a different R, which is now announced rather than inferred from compiler output.