### PR TITLE
test: give CI the PPM binary repo on Ubuntu, not just one developer

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -152,19 +152,30 @@ lp2 <- c(head(lp, 1), tail(lp, 1))
 orig <- setLibPaths(lp2, standAlone = TRUE)
 withr::defer(.libPaths(lp), envir = teardown_env())
 
+## PPM binaries on Ubuntu/Debian, for everyone -- this was previously inside the
+## `emcintir` block, so CI never got it. Without it, Linux resolves everything
+## from source (CRAN publishes no Linux binaries), so every dependency the tests
+## install is compiled. That is why the Ubuntu legs run far longer than the
+## Windows ones, where CRAN serves binaries from the ordinary repo.
+## `use-public-rspm: true` in the workflow only covers setup-r-dependencies
+## installing Require's own deps; the tests call Require::Install(), which
+## resolves through getOption("repos") as the test session leaves it.
+## positBinaryRepos() derives the distro codename; guarded, so a no-op elsewhere.
+if (isUbuntuOrDebian()) {
+  reposPPM <- c(PPM = positBinaryRepos(), getOption("repos"))
+  withr::local_options(
+    .local_envir = teardown_env(),
+    repos = reposPPM[!duplicated(reposPPM)]  # keep names
+  )
+}
+
 if (Sys.info()["user"] %in% "emcintir") {
   secretPath <- if (isWindows()) "c:/Eliot/.secret" else "/home/emcintir/.secret"
-  repos <- getOption("repos")
-  if (isUbuntuOrDebian()) {
-    repos <- c(PPM = positBinaryRepos(), repos)
-  }
-  repos <- repos[!duplicated(repos)] # keep names
   withr::local_options(
     .local_envir = teardown_env(),
     Require.cloneFrom = Sys.getenv("R_LIBS_USER"),
     "Require.installPackagesSys" = Require.installPackageSys,
     Ncpus = 8,
-    repos = repos,
     Require.origLibPathForTests = .libPaths()[1],
     gargle_oauth_email = "eliotmcintire@gmail.com",
     gargle_oauth_cache = secretPath) # , .local_envir = teardown_env())


### PR DESCRIPTION
The PPM prepend in `tests/testthat/setup.R` was inside

```r
if (Sys.info()["user"] %in% "emcintir") {
  ...
  if (isUbuntuOrDebian()) repos <- c(PPM = positBinaryRepos(), repos)
```

so on CI -- user `runner` -- the tests never got it.

## Effect

On Linux the tests resolve every package **from source**: CRAN publishes no Linux binaries, and PPM's `__linux__/<codename>` path is what serves them. On Windows CRAN serves binaries from the ordinary repo, so those legs finish quickly. That asymmetry is the Ubuntu legs running far longer than the Windows ones.

`use-public-rspm: true` in the workflow does not cover it: that configures the repo for `setup-r-dependencies` installing Require's own dependencies, but the tests then call `Require::Install()`, which resolves through `getOption("repos")` as the test session leaves it.

## Change

The PPM prepend moves out of the username gate, still guarded by `isUbuntuOrDebian()` so it is a no-op elsewhere. The `.secret` / gargle options stay gated -- those genuinely are personal; the repo choice is not.

Verified locally:

```
positBinaryRepos(): https://packagemanager.posit.co/cran/__linux__/noble/latest
resulting repos:
   PPM  = https://packagemanager.posit.co/cran/__linux__/noble/latest
   CRAN = https://cloud.r-project.org
```

`positBinaryRepos()` derives the codename via `lsb_release -cs`, so it is correct on the runner rather than hardcoded. If that ever fails, `system(intern = TRUE)` returns `character(0)` and `paste0()` collapses the URL to `character(0)` -- the prepend becomes a no-op rather than a malformed repo.

## Follow-on

If this cuts the Ubuntu legs enough, some of the tests currently gated behind `skip_on_ci()` / `R_REQUIRE_RUN_LONG_CI` may become affordable on CI. Worth revisiting once there is a timing comparison -- those gates are where today's two real bugs were hiding.