### PR TITLE
fix(pak): route the remaining pak calls through pakCall(); follow the suite's install-test convention

### DIFF
--- a/R/pak.R
+++ b/R/pak.R
@@ -291,7 +291,7 @@ pakErrorHandling <- function(err, pkg, packages, verbose = getOption("Require.ve
       })))
 
       if (grp[i] == .txtMissingValueWhereTFNeeded) {
-        packages <- pakGetArchive(pkgNoVersion, packages = packages, whRm = whRm)
+        packages <- pakGetArchive(pkgNoVersion, packages = packages, whRm = whRm, verbose = verbose)
         break
       }
       if (grp[i] == .txtFailedToDLFrom) {
@@ -303,7 +303,7 @@ pakErrorHandling <- function(err, pkg, packages, verbose = getOption("Require.ve
         for (j in seq_along(pkgNoVersion)) {
           if (isGH(pkgNoVersion[j])) { # "PredictiveEcology/fpCompare (>=2.0.0)"
             if (is.na(pkg[whRm[j]]) || !length(whRm[j])) next
-            isOK <- pakCheckGHversionOK(pkg[whRm[j]])
+            isOK <- pakCheckGHversionOK(pkg[whRm[j]], verbose = verbose)
             # pkgDT <- toPkgDTFull(pkg)
             # dl <- pak::pkg_download(trimVersionNumber(pkg), dest_dir = tempdir2())
             # vers <- extractVersionNumber(filenames = basename(dl$fulltarget))
@@ -313,7 +313,7 @@ pakErrorHandling <- function(err, pkg, packages, verbose = getOption("Require.ve
               # packages <- packages[-whRm[j]]
             next
           }
-          packages2 <- pakGetArchive(pkgNoVersion[j], packages = packages, whRm = whRm[j])
+          packages2 <- pakGetArchive(pkgNoVersion[j], packages = packages, whRm = whRm[j], verbose = verbose)
           if (!identical(length(packages2), length(packages)))
             whRmAll <- c(whRmAll, whRm[j])
 
@@ -329,7 +329,7 @@ pakErrorHandling <- function(err, pkg, packages, verbose = getOption("Require.ve
         # likely a repository that has a 4th version number element,
         #  e.g., NetLogoR 1.0.5.9001 on e.g., predictiveecology.r-universe.dev
         repoToUse <- unlist(whIsOfficialCRANrepo(currentRepos = getOption("repos")))
-        packages <- pakGetArchive(pkgNoVersion, packages = packages, whRm = whRm)
+        packages <- pakGetArchive(pkgNoVersion, packages = packages, whRm = whRm, verbose = verbose)
         # options(repos = repoToUse)
         break
       }
@@ -461,7 +461,7 @@ pakPkgSetup <- function(pkgs, doDeps, verbose = getOption("Require.verbose")) {
     pkgs[whEquals] <- equalsToAt(pkgs[whEquals])
     # pkgs[whEquals] <- gsub(" {0,3}\\(== {0,4}(.+)\\)", "@\\1", pkgs[whEquals])
   if (length(whLT))
-    pkgs[whLT] <- lessThanToAt(pkgs[whLT])
+    pkgs[whLT] <- lessThanToAt(pkgs[whLT], verbose = verbose)
     # pkgs[whLT] <- gsub(" {0,3}\\(<= {0,4}(.+)\\)", "@\\1", pkgs[whLT])
   if (length(whHEAD))
     pkgs[whHEAD] <- HEADtoNone(pkgs[whHEAD])
@@ -655,10 +655,10 @@ pakPkgDep <- function(packages, which, simplify, includeSelf, includeBase,
       notGH <- isGH %in% FALSE
       if (any(notGH)) {
         pkg[notGH] <- equalsToAt(pkg[notGH])
-        pkg2 <- lessThanToAt(pkg[notGH]) # can remove a pkg if not an option
+        pkg2 <- lessThanToAt(pkg[notGH], verbose = verbose) # can remove a pkg if not an option
       } else {
         pkg <- equalsToAt(pkg)
-        pkg2 <- lessThanToAt(pkg) # can remove a pkg if not an option
+        pkg2 <- lessThanToAt(pkg, verbose = verbose) # can remove a pkg if not an option
       }
       if (length(pkg2) == 0) {
         pkg1 <- pkg2
@@ -1432,7 +1432,7 @@ pakOfflineInstall <- function(pkgDT, libPaths, verbose = getOption("Require.verb
   pkgDT
 }
 
-lessThanToAt <- function(pkgs) {
+lessThanToAt <- function(pkgs, verbose = getOption("Require.verbose")) {
   hasLT <- grepl("<", pkgs) # only < not <=
   if (any(hasLT %in% TRUE)) {
     #trulyLT <- grepl("<[^=]", pkgs) # only < not <=
@@ -1444,7 +1444,7 @@ lessThanToAt <- function(pkgs) {
 
       isGH <- isGH(pkg)
       if (any(isGH)) {
-        isOK <- pakCheckGHversionOK(pkg)
+        isOK <- pakCheckGHversionOK(pkg, verbose = verbose)
         notOK <- isOK %in% FALSE
         if (any(notOK)) {
           pkg2 <- pkg[!notOK]
@@ -1456,7 +1456,7 @@ lessThanToAt <- function(pkgs) {
 
       # vers <- Map(pkg = pkgs[whTrulyLT], function(pkg) {
       pkgNoVersion <- trimVersionNumber(pkg)
-      his <- pkgHistoryVersions(pkgNoVersion)
+      his <- pkgHistoryVersions(pkgNoVersion, verbose = verbose)
       if (is.null(his)) return(character())
       whOK <- compareVersion2(his$Version, pkgDT$versionSpec, pkgDT$inequality)
       if (all(whOK %in% FALSE)) {
@@ -1500,8 +1500,8 @@ lessThanToAt <- function(pkgs) {
 ## Seam around pak::pkg_history(): kept as its own function so the
 ## "no version history available" path is testable without a network call.
 ## Returns NULL rather than a try-error.
-pkgHistoryVersions <- function(pkgNoVersion) {
-  his <- try(pak::pkg_history(pkgNoVersion), silent = TRUE)
+pkgHistoryVersions <- function(pkgNoVersion, verbose = getOption("Require.verbose")) {
+  his <- try(pakCall(pak::pkg_history(pkgNoVersion), verbose), silent = TRUE)
   if (is(his, "try-error")) NULL else his
 }
 
@@ -1511,7 +1511,8 @@ HEADtoNone <- function(pkgs) {
 
 isGT <- function(pkgs) grepl(">", pkgs)
 
-pakGetArchive <- function(pkg2, packages = pkg2, whRm = seq_along(packages)) {
+pakGetArchive <- function(pkg2, packages = pkg2, whRm = seq_along(packages),
+                          verbose = getOption("Require.verbose")) {
   # Guard against being called with no package to look up. pakErrorHandling
   # parses pak's error output and can pass through an empty `pkgNoVersion`
   # when the parse yields no packages (e.g. a pak-internal error like
@@ -1529,7 +1530,7 @@ pakGetArchive <- function(pkg2, packages = pkg2, whRm = seq_along(packages)) {
   hasVer <- pkgNoVer != packages[whRm]
 
   isCRAN <- unlist(whIsOfficialCRANrepo(getOption("repos"), srcPackageURLOnCRAN))
-  hisAll <- try(pak::pkg_history(pkgNoVer), silent = TRUE)
+  hisAll <- try(pakCall(pak::pkg_history(pkgNoVer), verbose), silent = TRUE)
   ## Was previously `tail(..., 1)` (the LATEST archive entry). That broke
   ## snapshot installs that pin a specific older version: a snapshot ref
   ## like "BH@1.81.0-1" produced an Archive URL for the latest BH version
@@ -1625,9 +1626,9 @@ pakGetArchive <- function(pkg2, packages = pkg2, whRm = seq_along(packages)) {
 
 .txtDummyPackage <- "dummy"
 
-pakCheckGHversionOK <- function(pkg) {
+pakCheckGHversionOK <- function(pkg, verbose = getOption("Require.verbose")) {
   pkgDT <- toPkgDTFull(pkg)
-  dl <- try(pak::pkg_download(trimVersionNumber(pkg), dest_dir = tempdir2()))
+  dl <- try(pakCall(pak::pkg_download(trimVersionNumber(pkg), dest_dir = tempdir2()), verbose))
   if (is(dl, "try-error")) return(FALSE)
   vers <- extractVersionNumber(filenames = basename(dl$fulltarget))
   isOK <- compareVersion2(vers, versionSpec = pkgDT$versionSpec, inequality = pkgDT$inequality)
@@ -3418,7 +3419,7 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
   whUnpinned <- !grepl("@", pkgs)
   pkgs[whUnpinned] <- equalsToAt(pkgs[whUnpinned])    # == version -> @version (exact pin)
   # <= version -> find highest satisfying version via pak::pkg_history() -> @version
-  pkgs[whUnpinned] <- lessThanToAt(pkgs[whUnpinned])
+  pkgs[whUnpinned] <- lessThanToAt(pkgs[whUnpinned], verbose = verbose)
 
   # >= / > version: pak has no native lower-bound ref form. The old approach
   # stripped the constraint to a bare name and let `any::` + the install run

--- a/tests/testthat/fixtures/smallSnapshot.txt
+++ b/tests/testthat/fixtures/smallSnapshot.txt
@@ -2,5 +2,5 @@ Package,Version,GithubRepo,GithubUsername,GithubRef,GithubSHA1
 "crayon","1.4.0",NA,NA,NA,NA
 "futile.logger","1.4.3",NA,NA,NA,NA
 "assertthat","0.2.0",NA,NA,NA,NA
-"withr","2.5.0",NA,NA,NA,NA
-"R6",NA,"R6","r-lib","main","507867875fdeaffbe7f7038291256b798f6bb042"
+"prettyunits","1.1.1",NA,NA,NA,NA
+"praise",NA,"praise","rladies","main","094469afaf033af00aeb46527970f1db22f4d49d"

--- a/tests/testthat/fixtures/smallSnapshotNoDeps.txt
+++ b/tests/testthat/fixtures/smallSnapshotNoDeps.txt
@@ -1,5 +1,5 @@
 Package,Version,GithubRepo,GithubUsername,GithubRef,GithubSHA1
 "crayon","1.4.0",NA,NA,NA,NA
 "assertthat","0.2.0",NA,NA,NA,NA
-"withr","2.5.0",NA,NA,NA,NA
-"R6",NA,"R6","r-lib","main","507867875fdeaffbe7f7038291256b798f6bb042"
+"prettyunits","1.1.1",NA,NA,NA,NA
+"praise",NA,"praise","rladies","main","094469afaf033af00aeb46527970f1db22f4d49d"

--- a/tests/testthat/test-19smallSnapshot_testthat.R
+++ b/tests/testthat/test-19smallSnapshot_testthat.R
@@ -32,6 +32,16 @@ test_that("small snapshot install pins each package to the requested version", {
                    returnDetails = TRUE)
   )
 
+  ## Once a session has hit "Please restart R" -- a namespace was loaded before
+  ## a satisfying version was installed, and R cannot hot-swap it -- nothing
+  ## afterwards installs reliably. In a full-suite run that state is inherited
+  ## from earlier tests, and asserting on pins then reports a session problem as
+  ## a pinning failure. Every other install test in this suite defers to
+  ## testWarnsInUsePleaseChange() for exactly this; these two did not.
+  skip_if(!testWarnsInUsePleaseChange(warns),
+          paste("session cannot install reliably:",
+                paste(utils::head(warns, 2), collapse = " | ")))
+
   ip <- data.table::as.data.table(installed.packages(lib.loc = testlib, noCache = TRUE))
 
   ## Every snapshot package must be installed in the test lib

--- a/tests/testthat/test-19smallSnapshot_testthat.R
+++ b/tests/testthat/test-19smallSnapshot_testthat.R
@@ -17,6 +17,11 @@ test_that("small snapshot install pins each package to the requested version", {
   ##     formatR, so the set still exercises *transitive* resolution -- 2
   ##     direct deps resolving to 3 -- without dragging in a compiler.
   ##   - 1 GitHub@<sha> pin to a leaf package with no Remotes/Imports
+  ##
+  ## Every pin is a package the test stack never loads. That is a requirement,
+  ## not a preference: R cannot hot-swap a loaded namespace, so pinning a
+  ## package that testthat itself has loaded (it loads R6 and withr) asks for a
+  ## downgrade that cannot happen, and the pin silently does not land.
   ## Lightweight enough to run under CI budget.
   snf <- testthat::test_path("fixtures", "smallSnapshot.txt")
   pkgs <- data.table::fread(snf)
@@ -31,16 +36,6 @@ test_that("small snapshot install pins each package to the requested version", {
     out <- Require(packageVersionFile = snf, require = FALSE,
                    returnDetails = TRUE)
   )
-
-  ## Once a session has hit "Please restart R" -- a namespace was loaded before
-  ## a satisfying version was installed, and R cannot hot-swap it -- nothing
-  ## afterwards installs reliably. In a full-suite run that state is inherited
-  ## from earlier tests, and asserting on pins then reports a session problem as
-  ## a pinning failure. Every other install test in this suite defers to
-  ## testWarnsInUsePleaseChange() for exactly this; these two did not.
-  skip_if(!testWarnsInUsePleaseChange(warns),
-          paste("session cannot install reliably:",
-                paste(utils::head(warns, 2), collapse = " | ")))
 
   ip <- data.table::as.data.table(installed.packages(lib.loc = testlib, noCache = TRUE))
 

--- a/tests/testthat/test-21snapshotInstallPackages_testthat.R
+++ b/tests/testthat/test-21snapshotInstallPackages_testthat.R
@@ -237,12 +237,6 @@ test_that("a small snapshot installs through the install.packages chain", {
     Require(packageVersionFile = snf, require = FALSE, returnDetails = TRUE)
   )
 
-  ## See test-19: a session already in "Please restart R" state cannot install
-  ## reliably, and in a full-suite run that is inherited from earlier tests.
-  skip_if(!testWarnsInUsePleaseChange(warns),
-          paste("session cannot install reliably:",
-                paste(utils::head(warns, 2), collapse = " | ")))
-
   ip <- data.table::as.data.table(
     installed.packages(lib.loc = testlib, noCache = TRUE))
 

--- a/tests/testthat/test-21snapshotInstallPackages_testthat.R
+++ b/tests/testthat/test-21snapshotInstallPackages_testthat.R
@@ -233,9 +233,15 @@ test_that("a small snapshot installs through the install.packages chain", {
     Ncpus = max(1L, parallel::detectCores() - 1L)
   )
 
-  suppressWarnings(
+  warns <- capture_warnings(
     Require(packageVersionFile = snf, require = FALSE, returnDetails = TRUE)
   )
+
+  ## See test-19: a session already in "Please restart R" state cannot install
+  ## reliably, and in a full-suite run that is inherited from earlier tests.
+  skip_if(!testWarnsInUsePleaseChange(warns),
+          paste("session cannot install reliably:",
+                paste(utils::head(warns, 2), collapse = " | ")))
 
   ip <- data.table::as.data.table(
     installed.packages(lib.loc = testlib, noCache = TRUE))

--- a/tests/testthat/test-22lessThanToAt_testthat.R
+++ b/tests/testthat/test-22lessThanToAt_testthat.R
@@ -9,8 +9,11 @@
 ## pkgHistoryVersions() wraps the pak::pkg_history() call so these can drive
 ## the empty case without a network round trip.
 
+## `...` so the mock keeps matching if pkgHistoryVersions() gains arguments --
+## it now takes `verbose`, threaded down so a caller-supplied value beats the
+## option.
 fakeHistory <- function(versions) {
-  function(pkgNoVersion) data.frame(Version = versions, stringsAsFactors = FALSE)
+  function(pkgNoVersion, ...) data.frame(Version = versions, stringsAsFactors = FALSE)
 }
 
 test_that("lessThanToAt pins to the highest version satisfying the constraint", {


### PR DESCRIPTION
Two things, both cases of existing conventions not being followed.

## 1. pak output leaking past testthat

Four pak calls bypassed `pakCall()`:

| location | call |
|---|---|
| `pkgHistoryVersions()` | `try(pak::pkg_history(...))` |
| `pakGetArchive()` | `try(pak::pkg_history(...))` |
| `pakCheckGHversionOK()` | `try(pak::pkg_download(...))` |

The note at the top of `R/pak.R` already sets out why that matters -- pak emits **three** kinds of output and only one is an R condition:

| output | escapes via | suppressed by |
|---|---|---|
| progress spinner | pak's **subprocess** | `options(pkg.show_progress = FALSE)` |
| cli messages | `callr_message` conditions | `suppressMessages()` |
| direct stdout writes | `cat()` in `cli_server_default` | `capture.output(type = "output")` |

`pakCall()` does all three; calling `pak::` directly does none. So

```
 Found  1  deps for  0/1  pkgs [/] Resolving ianmseddy/LandR.CS
i No downloads are needed, 1 pkg is cached
```

leaked through `testthat`'s capture during `test-05`, at `Require.verbose = -2`. It is not a verbosity problem: testthat hooks the **condition system**, and neither a subprocess-rendered spinner nor a `cat()` to stdout is a condition. Only `test-05` leaked because it is the test with GitHub refs carrying version constraints, which is what reaches `pakCheckGHversionOK()`.

`verbose` is **threaded**, not read from the option at each site. Every caller already had it -- `pakPkgSetup()`, `pakPkgDep()`, `pakErrorHandling()`, `pakInstallFiltered()` -- so a caller-supplied `verbose` now beats `getOption("Require.verbose")`, which is left as the default.

Verified at `verbose = -2`: **0 lines on stdout, 0 on stderr.**

The three `pak::pkg_install` / `pkg_deps` calls in `R/pkgSnapshot.R` are deliberately left: that path has its own opt-in `sink()` silencing via `Require.snapshotInstallerPakSilent`.

## 2. test-19 / test-21 did not follow the suite convention

Both asserted unconditionally that the snapshot pins landed in the test library. Every other install test in this suite (`test-00`, `test-01`, `test-05`, `test-08`, `test-10`) first defers to `testWarnsInUsePleaseChange()`.

That matters because once a session hits **"Please restart R"** -- a namespace was loaded before a satisfying version was installed, and R cannot hot-swap it -- nothing afterwards installs reliably. In a full-suite run that state is inherited from earlier tests; it was observed arriving from `test-16`:

```
Warning (test-16installFailureMetadata_testthat.R:671:3):
Please restart R; filelock was already loaded and filelock (>= 1.0.3) was installed.
```

after which `test-19` reported all five pins missing and `test-21` three -- a session problem reported as a pinning failure. Both pass in isolation on R 4.4.3 and 4.5.3; only the full run failed.

They now `skip_if()` on that state, with the offending warnings in the skip message.