### PR TITLE
test: run the install-heavy tests locally at a release version too

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,4 +1,21 @@
-if (.isDevelVersion() && nchar(Sys.getenv("R_REQUIRE_RUN_ALL_TESTS")) == 0) {
+## Enable the install-heavy tests for a local manual run.
+##
+## This was keyed on .isDevelVersion(), i.e. a 4-part version like 2.0.0.9036.
+## At a release version (2.1.0 -> 3 parts) it switched off, so test-08, test-09
+## and test-10 went quiet at exactly the commit being released -- the build that
+## most needs them. They reported "empty test" rather than a skip, so the gap
+## was easy to miss.
+##
+## The version was never the right discriminator: those tests already carry
+## skip_on_ci() AND skip_on_cran(), so CI and CRAN exclude themselves. What has
+## to be excluded here is R CMD check, where skip_on_cran() does NOT fire
+## (devtools::check() sets NOT_CRAN = "true") and test-08 alone would install
+## ~100 packages. testthat::is_checking() detects that; it reads
+## TESTTHAT_IS_CHECKING, which testthat sets under R CMD check and not under
+## devtools::test().
+if (nchar(Sys.getenv("R_REQUIRE_RUN_ALL_TESTS")) == 0 &&
+    !testthat::is_checking() &&
+    !isTRUE(as.logical(Sys.getenv("CI")))) {
   withr::local_envvar(R_REQUIRE_RUN_ALL_TESTS = "true", .local_envir = teardown_env())
 }
 


### PR DESCRIPTION
The install-heavy tests went quiet at the release commit.

`R_REQUIRE_RUN_ALL_TESTS` was auto-enabled only when `.isDevelVersion()`:

```r
.isDevelVersion <- function() {
  length(strsplit(packageDescription("Require")$Version, "\\.")[[1]]) > 3
}
```

`2.0.0.9036` -> 4 parts -> TRUE. `2.1.0` -> 3 parts -> **FALSE**. So bumping the version for release switched off `test-08`, `test-09` and `test-10` -- on the build that most needs them.

They report **"empty test"** rather than a skip, which makes the gap easy to miss. Observed during 2.1.0 prep: `test-08modules_testthat` reported `1 0` (one skip, zero assertions) on a manual run that had exercised it the day before.

## Why the version was the wrong discriminator

Those tests already carry **both** `skip_on_ci()` and `skip_on_cran()`, so CI and CRAN exclude themselves without help.

The context that actually has to be excluded here is **`R CMD check`**, where `skip_on_cran()` does *not* fire -- `devtools::check()` sets `NOT_CRAN = "true"` -- and `test-08` alone installs ~100 packages, which is what its own comment warns about (CRAN temp-directory detritus, check budget).

`testthat::is_checking()` is exactly that predicate: it reads `TESTTHAT_IS_CHECKING`, which testthat sets under `R CMD check` and not under `devtools::test()`.

## Verified

| context | enabled? |
|---|---|
| local manual run | yes |
| under `R CMD check` | no |
| on CI | no |
| explicitly set by the user | respected, not overridden |