### PR TITLE
test: stop pinning packages the test stack loads in smallSnapshot fixtures

### DIFF
--- a/tests/testthat/fixtures/smallSnapshot.txt
+++ b/tests/testthat/fixtures/smallSnapshot.txt
@@ -1,6 +1,6 @@
 Package,Version,GithubRepo,GithubUsername,GithubRef,GithubSHA1
-"crayon","1.4.0",NA,NA,NA,NA
+"iterators","1.0.12",NA,NA,NA,NA
+"itertools","0.1-1",NA,NA,NA,NA
 "futile.logger","1.4.3",NA,NA,NA,NA
 "assertthat","0.2.0",NA,NA,NA,NA
-"prettyunits","1.1.1",NA,NA,NA,NA
-"praise",NA,"praise","rladies","main","094469afaf033af00aeb46527970f1db22f4d49d"
+"R.methodsS3",NA,"R.methodsS3","HenrikBengtsson","master","c842db47c1eab9524bddfd789955ca0c9aa817bc"

--- a/tests/testthat/fixtures/smallSnapshotNoDeps.txt
+++ b/tests/testthat/fixtures/smallSnapshotNoDeps.txt
@@ -1,5 +1,5 @@
 Package,Version,GithubRepo,GithubUsername,GithubRef,GithubSHA1
-"crayon","1.4.0",NA,NA,NA,NA
+"iterators","1.0.12",NA,NA,NA,NA
+"futile.options","1.0.0",NA,NA,NA,NA
 "assertthat","0.2.0",NA,NA,NA,NA
-"prettyunits","1.1.1",NA,NA,NA,NA
-"praise",NA,"praise","rladies","main","094469afaf033af00aeb46527970f1db22f4d49d"
+"R.methodsS3",NA,"R.methodsS3","HenrikBengtsson","master","c842db47c1eab9524bddfd789955ca0c9aa817bc"

--- a/tests/testthat/test-19smallSnapshot_testthat.R
+++ b/tests/testthat/test-19smallSnapshot_testthat.R
@@ -1,28 +1,43 @@
 test_that("small snapshot install pins each package to the requested version", {
   ## CRAN policy: tests may only download/install packages listed in Suggests.
-  ## The fixture pins crayon / futile.logger / assertthat / R6 (and their
-  ## deps), which are not Require Suggests -- so this is CI-only.
+  ## The fixture pins packages that are not Require Suggests -- so this is
+  ## CI-only.
   skip_on_cran()
   setupInitial <- setupTest()
   skip_if_offline2()
 
   ## A 5-package snapshot that exercises the version-pin paths Require
-  ## must support, without dragging in the LandR-shaped Remotes mess:
+  ## must support:
   ##   - 4 CRAN packages pinned to non-current versions (served by CRAN
   ##     Archive forever). None needs compilation, and neither does anything
   ##     they pull in: old packages that need a compiler are their own beast,
   ##     and the answer there is "ask for a newer version", not something
   ##     Require tries to solve.
-  ##   - futile.logger imports lambda.r + futile.options, and lambda.r imports
-  ##     formatR, so the set still exercises *transitive* resolution -- 2
-  ##     direct deps resolving to 3 -- without dragging in a compiler.
-  ##   - 1 GitHub@<sha> pin to a leaf package with no Remotes/Imports
+  ##   - transitive resolution is exercised twice: futile.logger imports
+  ##     lambda.r + futile.options, and lambda.r imports formatR; itertools
+  ##     imports iterators, which is *also* pinned explicitly, so a pinned
+  ##     dependency has to be honoured as a dependency too.
+  ##   - 1 GitHub@<sha> pin to a leaf package with no Remotes.
   ##
-  ## Every pin is a package the test stack never loads. That is a requirement,
-  ## not a preference: R cannot hot-swap a loaded namespace, so pinning a
-  ## package that testthat itself has loaded (it loads R6 and withr) asks for a
-  ## downgrade that cannot happen, and the pin silently does not land.
-  ## Lightweight enough to run under CI budget.
+  ## Every pin MUST be a package the test stack never loads. That is a hard
+  ## requirement, not a preference: R cannot hot-swap a loaded namespace, so
+  ## pinning a package testthat has loaded asks for a downgrade that cannot
+  ## happen, and the pin silently does not land.
+  ##
+  ## Getting this wrong is subtle, because the offending namespaces load
+  ## *lazily* -- so the test passes in isolation and fails in a full-suite
+  ## run, on some machines only. An earlier version of this fixture pinned
+  ## crayon, prettyunits and praise; all three are in the dependency closure
+  ## of testthat/devtools/pak (praise is a declared testthat Import, loaded
+  ## for the encouragement message on success), and unlinking `testlib` also
+  ## pulled praise out from under testthat mid-run.
+  ##
+  ## To re-verify the current picks, check that none is in the closure:
+  ##   ap <- available.packages()
+  ##   cl <- tools::package_dependencies(c("testthat", "devtools", "pak",
+  ##           "pkgload", "data.table", "cli", "covr", "withr"), db = ap,
+  ##           recursive = TRUE, which = c("Depends", "Imports", "LinkingTo"))
+  ##   pkgs$Package %in% unique(c(unlist(cl), names(cl)))   # must be all FALSE
   snf <- testthat::test_path("fixtures", "smallSnapshot.txt")
   pkgs <- data.table::fread(snf)
 

--- a/tests/testthat/test-21snapshotInstallPackages_testthat.R
+++ b/tests/testthat/test-21snapshotInstallPackages_testthat.R
@@ -191,9 +191,10 @@ test_that("a small snapshot installs through the install.packages chain", {
   ## post-install diagnostic -- is actually executed. Kept to the same
   ## 5-package fixture so the CI cost is the same as test-19's.
   ## CRAN policy: a package's tests may only download/install packages listed
-  ## in its own Suggests. This installs the fixture's pins (crayon,
-  ## futile.logger, assertthat, R6 and their deps), none of which are Require
-  ## Suggests, so it is CI-only. The tests above install nothing and run
+  ## in its own Suggests. This installs the fixture's pins (iterators,
+  ## futile.options, assertthat and the GitHub R.methodsS3 pin), none of which
+  ## are Require Suggests, so it is CI-only. As in test-19, none may be a
+  ## package the test stack loads -- see the note there. The tests above install nothing and run
   ## everywhere.
   skip_on_cran()
   ## Windows: the chain has no binary path there -- the code's own comment says


### PR DESCRIPTION
Fixes the intermittent `test-19`/`test-21` failures that showed up in full-suite runs on some machines while passing in isolation everywhere.

## Cause

Three fixture pins are inside the dependency closure of `testthat`/`devtools`/`pak`: **`crayon`, `prettyunits`, `praise`**. R cannot hot-swap a loaded namespace, so a pin against an already-loaded package silently does not land, and the assertion reports it missing:

```
Please restart R; crayon was already loaded and crayon (== 1.4.0) was installed.
crayon (==1.4.0)  FALSE      # ... all five pins FALSE
```

The test comment already forbade exactly this — the fixture broke its own rule.

## Why it looked flaky

Those namespaces load **lazily**. `praise` is a declared `testthat` Import, loaded for the encouragement message on success. So whether a pin lands depends on what ran before and how much reporter output was produced — hence isolation passes, some full suites pass, and it varies by machine. Unlinking `testlib` also pulled `praise` out from under testthat mid-run, exiting non-zero after a green suite.

## Change

Only the three in-closure pins are replaced. `assertthat` and `futile.logger` stay — other tests reference them, but they are outside the closure and never load. *Referenced* is not *loaded*, and only loaded matters here.

| pin | role |
|---|---|
| `iterators 1.0.12` | leaf, archived version |
| `itertools 0.1-1` | transitive → `iterators`, which is also pinned explicitly, so a pinned dependency must be honoured as one |
| `HenrikBengtsson/R.methodsS3@c842db47` | GitHub@SHA leaf |
| `futile.logger 1.4.3`, `assertthat 0.2.0` | unchanged |

None needs compilation. The comment now records the trap and a copy-pasteable closure check for future picks.

## Verification

`FAIL 0 | PASS 32` across both files, zero namespace-clash warnings, exit 0. The per-pin version assertions pass, so pins land at the exact requested versions.

Not a release blocker for 2.1.0 — both files are `skip_on_cran()`.