### PR TITLE
test: derive the test gate from NOT_CRAN/CI; drop dead helpers; @examplesIf

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,11 +38,14 @@ jobs:
           # deps in well under an hour.
           - {os: ubuntu-latest,   r: 'devel'}
           # Single matrix entry that opts in to the slow integration tests
-          # (5 archived-CRAN install round-trips in test-16 — measured at
-          # 340s vs ~50s for the rest of the test suite). Other matrix
+          # in test-16: two archived-CRAN install round-trips (measured at
+          # 103s and 20s) and the PSPclean-style cascade. Other matrix
           # entries skip those via R_REQUIRE_RUN_LONG_CI gate so the 11-job
           # matrix doesn't camp on GHA's 20-job concurrency cap. Coverage
           # of the slow path is preserved on this one entry.
+          # The cheap tests in that file (pakGetArchive URL construction,
+          # 2.2s for both; .lastInstallFailures, 3.4s) are NOT gated -- they
+          # install nothing worth gating and run on every entry.
           - {os: ubuntu-latest,   r: 'release', runLong: true}  ## currently 4.5
           - {os: ubuntu-latest,   r: 'oldrel-1'} ## currently 4.4
           - {os: ubuntu-latest,   r: 'oldrel-2'} ## currently 4.3
@@ -52,9 +55,10 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       # Set to "true" only on the matrix entry tagged `runLong: true`.
-      # Tests that read this env (currently the 5 archived-CRAN install
-      # round-trips in test-16installFailureMetadata) bypass skip_on_ci()
-      # only when this is non-empty.
+      # Tests that read this env (3 in test-16installFailureMetadata: two
+      # archived-CRAN install round-trips and the PSPclean cascade; plus the
+      # pkgDepTopoSort section of test-06, ~626s) bypass skip_on_ci() only
+      # when this is non-empty.
       R_REQUIRE_RUN_LONG_CI: ${{ matrix.config.runLong && 'true' || '' }}
 
     steps:

--- a/R/Require2.R
+++ b/R/Require2.R
@@ -179,8 +179,7 @@ utils::globalVariables(c(
 #' @importFrom utils available.packages capture.output compareVersion
 #' @importFrom utils install.packages packageVersion
 #'
-#' @examples
-#' \dontrun{
+#' @examplesIf Require:::.runLongExamples()
 #' opts <- Require:::.setupExample()
 #'
 #' library(Require)
@@ -191,53 +190,50 @@ utils::globalVariables(c(
 #' # unquoted version
 #' Require(c(tools, utils))
 #'
-#' if (Require:::.runLongExamples()) {
-#'   # Install in a new local library (libPaths)
-#'   tempPkgFolder <- file.path(tempdir(), "Require/Packages")
-#'   # use standAlone, means it will put it in libPaths, even if it already exists
-#'   #   in another local library (e.g., personal library)
-#'   Install("crayon", libPaths = tempPkgFolder, standAlone = TRUE)
+#' # Install in a new local library (libPaths)
+#' tempPkgFolder <- file.path(tempdir(), "Require/Packages")
+#' # use standAlone, means it will put it in libPaths, even if it already exists
+#' #   in another local library (e.g., personal library)
+#' Install("crayon", libPaths = tempPkgFolder, standAlone = TRUE)
 #'
-#'   # Mutual dependencies, only installs once -- e.g., cli
-#'   tempPkgFolder <- file.path(tempdir(), "Require/Packages")
-#'   Install(c("cli", "R6"), libPaths = tempPkgFolder, standAlone = TRUE)
+#' # Mutual dependencies, only installs once -- e.g., cli
+#' tempPkgFolder <- file.path(tempdir(), "Require/Packages")
+#' Install(c("cli", "R6"), libPaths = tempPkgFolder, standAlone = TRUE)
 #'
-#'   # Mutual dependencies, only installs once -- e.g., rlang
-#'   tempPkgFolder <- file.path(tempdir(), "Require/Packages")
-#'   Install(c("rlang", "ellipsis"), libPaths = tempPkgFolder, standAlone = TRUE)
+#' # Mutual dependencies, only installs once -- e.g., rlang
+#' tempPkgFolder <- file.path(tempdir(), "Require/Packages")
+#' Install(c("rlang", "ellipsis"), libPaths = tempPkgFolder, standAlone = TRUE)
 #'
-#'   #####################################################################################
-#'   # Isolated projects -- Use a project folder and pass to libPaths or set .libPaths() #
-#'   #####################################################################################
-#'   # GitHub packages
-#'   if (requireNamespace("gitcreds", quietly = TRUE)) {
-#'     # if (is(try(gitcreds::gitcreds_get(), silent = TRUE), "gitcreds")) {
-#'     ProjectPackageFolder <- file.path(tempdir(), "Require/ProjectA")
-#'     if (requireNamespace("curl")) {
-#'       Require("PredictiveEcology/fpCompare@development",
-#'         libPaths = ProjectPackageFolder,
-#'       )
-#'     }
-#'
-#'     # No install because it is there already
-#'     Install("PredictiveEcology/fpCompare@development",
+#' #####################################################################################
+#' # Isolated projects -- Use a project folder and pass to libPaths or set .libPaths() #
+#' #####################################################################################
+#' # GitHub packages
+#' if (requireNamespace("gitcreds", quietly = TRUE)) {
+#'   # if (is(try(gitcreds::gitcreds_get(), silent = TRUE), "gitcreds")) {
+#'   ProjectPackageFolder <- file.path(tempdir(), "Require/ProjectA")
+#'   if (requireNamespace("curl")) {
+#'     Require("PredictiveEcology/fpCompare@development",
 #'       libPaths = ProjectPackageFolder,
-#'     ) # the latest version on GitHub
-#'
-#'     ############################################################################
-#'     # Mixing and matching GitHub, CRAN, with and without version numbering
-#'     ############################################################################
-#'     pkgs <- c(
-#'       "remotes (<=2.4.1)", # old version
-#'       "digest (>= 0.6.28)", # recent version
-#'       "PredictiveEcology/fpCompare@a0260b8476b06628bba0ae73af3430cce9620ca0" # exact version
 #'     )
-#'     Require::Require(pkgs, libPaths = ProjectPackageFolder)
-#'     # }
 #'   }
-#'   Require:::.cleanup(opts)
+#'
+#'   # No install because it is there already
+#'   Install("PredictiveEcology/fpCompare@development",
+#'     libPaths = ProjectPackageFolder,
+#'   ) # the latest version on GitHub
+#'
+#'   ############################################################################
+#'   # Mixing and matching GitHub, CRAN, with and without version numbering
+#'   ############################################################################
+#'   pkgs <- c(
+#'     "remotes (<=2.4.1)", # old version
+#'     "digest (>= 0.6.28)", # recent version
+#'     "PredictiveEcology/fpCompare@a0260b8476b06628bba0ae73af3430cce9620ca0" # exact version
+#'   )
+#'   Require::Require(pkgs, libPaths = ProjectPackageFolder)
+#'   # }
 #' }
-#' }
+#' Require:::.cleanup(opts)
 #'
 Require <- function(packages,
                     packageVersionFile,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -630,17 +630,8 @@ SysInfo <-
   options(opts$opts)
 }
 
-#' @importFrom utils packageDescription
-.isDevelVersion <- function() {
-  length(strsplit(packageDescription("Require")$Version, "\\.")[[1]]) > 3
-}
-
-.runLongTests <- function() {
-  .isDevelVersion() || Sys.getenv("R_REQUIRE_RUN_ALL_TESTS") == "true"
-}
-
 .runLongExamples <- function() {
-  # Auto-enable based on .isDevelVersion() is unsafe: with
+  # Auto-enabling from the package version is unsafe: with
   # `--run-dontrun --run-donttest` (default in r-lib/actions/check-r-package),
   # every dev-version R CMD check runs the full Require::Install() cascade
   # for every example in Require.Rd — hours on a cold CI runner.

--- a/R/pkgDep.R
+++ b/R/pkgDep.R
@@ -41,16 +41,12 @@ utils::globalVariables(
 #' A possibly ordered, named (with packages as names) list where list elements
 #' are either full reverse depends.
 #'
-#' @examples
-#' \dontrun{
-#' if (Require:::.runLongExamples()) {
-#'   opts <- Require:::.setupExample()
+#' @examplesIf Require:::.runLongExamples()
+#' opts <- Require:::.setupExample()
 #'
-#'   pkgDepTopoSort(c("Require", "data.table"), reverse = TRUE)
+#' pkgDepTopoSort(c("Require", "data.table"), reverse = TRUE)
 #'
-#'   Require:::.cleanup(opts)
-#' }
-#' }
+#' Require:::.cleanup(opts)
 #'
 pkgDepTopoSort <- function(packages,
                            deps,
@@ -639,16 +635,12 @@ DESCRIPTIONFileDepsV <-
 #' listed in this final list, then it means that it is also a recursive
 #' dependency elsewhere, so its removal has no effect.
 #' @inheritParams Require
-#' @examples
-#' \dontrun{
-#' if (Require:::.runLongExamples()) {
-#'   opts <- Require:::.setupExample()
+#' @examplesIf Require:::.runLongExamples()
+#' opts <- Require:::.setupExample()
 #'
-#'   pkgDepIfDepRemoved("reproducible", "data.table")
+#' pkgDepIfDepRemoved("reproducible", "data.table")
 #'
-#'   Require:::.cleanup(opts)
-#' }
-#' }
+#' Require:::.cleanup(opts)
 #'
 pkgDepIfDepRemoved <-
   function(pkg = character(),
@@ -1598,18 +1590,14 @@ getVersionOptionPkgEnv <- function(psnNoVersion, verNum, inequ) {
 #' i.e., the first order dependencies, and runs the `pkgDep` on those.
 #' @rdname pkgDep
 #' @export
-#' @examples
-#' \dontrun{
-#' if (Require:::.runLongExamples()) {
-#'   opts <- Require:::.setupExample()
+#' @examplesIf Require:::.runLongExamples()
+#' opts <- Require:::.setupExample()
 #'
-#'   pkgDep2("reproducible")
-#'   # much bigger one
-#'   pkgDep2("tidyverse")
+#' pkgDep2("reproducible")
+#' # much bigger one
+#' pkgDep2("tidyverse")
 #'
-#'   Require:::.cleanup(opts)
-#' }
-#' }
+#' Require:::.cleanup(opts)
 pkgDep2 <- function(...) {
   dots <- list(...)
   dots$recursive <- FALSE

--- a/R/pkgDep3.R
+++ b/R/pkgDep3.R
@@ -76,19 +76,15 @@ utils::globalVariables(c(
 #' @export
 #' @rdname pkgDep
 #'
-#' @examples
-#' \dontrun{
-#' if (Require:::.runLongExamples()) {
-#'   opts <- Require:::.setupExample()
+#' @examplesIf Require:::.runLongExamples()
+#' opts <- Require:::.setupExample()
 #'
-#'   pkgDep("tidyverse", recursive = TRUE)
+#' pkgDep("tidyverse", recursive = TRUE)
 #'
-#'   # GitHub, local, and CRAN packages
-#'   pkgDep(c("PredictiveEcology/reproducible", "Require", "plyr"))
+#' # GitHub, local, and CRAN packages
+#' pkgDep(c("PredictiveEcology/reproducible", "Require", "plyr"))
 #'
-#'   Require:::.cleanup(opts)
-#' }
-#' }
+#' Require:::.cleanup(opts)
 pkgDep <- function(packages,
                    libPaths,
                    which = c("Depends", "Imports", "LinkingTo"),
@@ -1588,6 +1584,7 @@ appendRecursiveToDeps <- function(pkgDT, caTr, depFa, caFa, snFa, depTr, snTr) {
 
 
 #' @include pkgDep.R
+#' @importFrom utils packageDescription
 RequireDependencies <- function(libPaths = .libPaths()) {
   localRequireDir <- file.path(libPaths, "Require")
   de <- dir.exists(localRequireDir)

--- a/R/pkgSnapshot.R
+++ b/R/pkgSnapshot.R
@@ -156,42 +156,38 @@
 #' @inheritParams pkgDep
 #' @importFrom data.table fwrite
 #' @importFrom utils write.table
-#' @examples
-#' \dontrun{
-#' if (Require:::.runLongExamples()) {
-#'   opts <- Require:::.setupExample()
+#' @examplesIf Require:::.runLongExamples()
+#' opts <- Require:::.setupExample()
 #'
-#'   # install one archived version so that below does something interesting
-#'   libForThisEx <- tempdir2("Example")
-#'   Require("crayon (==1.5.1)", libPaths = libForThisEx, require = FALSE)
-#'   # Normal use -- using the libForThisEx for example;
-#'   #    normally libPaths would be omitted to get all
-#'   #    packages in user or project library
-#'   tf <- tempfile()
+#' # install one archived version so that below does something interesting
+#' libForThisEx <- tempdir2("Example")
+#' Require("crayon (==1.5.1)", libPaths = libForThisEx, require = FALSE)
+#' # Normal use -- using the libForThisEx for example;
+#' #    normally libPaths would be omitted to get all
+#' #    packages in user or project library
+#' tf <- tempfile()
 #'
-#'   # writes to getOption("Require.packageVersionFile")
-#'   # within project; also returns a vector
-#'   # of packages with version
-#'   pkgs <- pkgSnapshot(
-#'     packageVersionFile = tf,
-#'     libPaths = libForThisEx, standAlone = TRUE # only this library
-#'   )
+#' # writes to getOption("Require.packageVersionFile")
+#' # within project; also returns a vector
+#' # of packages with version
+#' pkgs <- pkgSnapshot(
+#'   packageVersionFile = tf,
+#'   libPaths = libForThisEx, standAlone = TRUE # only this library
+#' )
 #'
-#'   # Now move this file to another computer e.g. by committing in git,
-#'   #   emailing, googledrive
-#'   #   on next computer/project
-#'   Require(packageVersionFile = tf, libPaths = libForThisEx)
+#' # Now move this file to another computer e.g. by committing in git,
+#' #   emailing, googledrive
+#' #   on next computer/project
+#' Require(packageVersionFile = tf, libPaths = libForThisEx)
 #'
-#'   # Using pkgSnapshot2 to get the vector of packages and versions
-#'   pkgs <- pkgSnapshot2(
-#'     libPaths = libForThisEx, standAlone = TRUE
-#'   )
-#'   Install(pkgs) # will install packages from previous line
+#' # Using pkgSnapshot2 to get the vector of packages and versions
+#' pkgs <- pkgSnapshot2(
+#'   libPaths = libForThisEx, standAlone = TRUE
+#' )
+#' Install(pkgs) # will install packages from previous line
 #'
-#'   Require:::.cleanup(opts)
-#'   unlink(getOption("Require.packageVersionFile"))
-#' }
-#' }
+#' Require:::.cleanup(opts)
+#' unlink(getOption("Require.packageVersionFile"))
 #'
 #' @rdname pkgSnapshot
 pkgSnapshot <- function(packageVersionFile = getOption("Require.packageVersionFile"),

--- a/R/setLibPaths.R
+++ b/R/setLibPaths.R
@@ -37,33 +37,29 @@
 #' @export
 #' @importFrom utils compareVersion
 #' @inheritParams Require
-#' @examples
-#' \dontrun{
-#' if (Require:::.runLongExamples()) {
-#'   opts <- Require:::.setupExample()
-#'   origDir <- setwd(tempdir())
-#'   td <- tempdir()
-#'   setLibPaths(td) # set a new R package library locally
-#'   setLibPaths() # reset it to original
-#'   setwd(origDir)
-#'   # Using standAlone = FALSE means that newly installed packages
-#'   #   will be installed
-#'   #   in the new package library, but loading packages can come
-#'   #   from any of the ones listed in .libPaths()
+#' @examplesIf Require:::.runLongExamples()
+#' opts <- Require:::.setupExample()
+#' origDir <- setwd(tempdir())
+#' td <- tempdir()
+#' setLibPaths(td) # set a new R package library locally
+#' setLibPaths() # reset it to original
+#' setwd(origDir)
+#' # Using standAlone = FALSE means that newly installed packages
+#' #   will be installed
+#' #   in the new package library, but loading packages can come
+#' #   from any of the ones listed in .libPaths()
 #'
-#'   # will have 2 or more paths
-#'   otherLib <- file.path(td, "newProjectLib")
-#'   setLibPaths(otherLib, standAlone = FALSE)
-#'   # Can restart R, and changes will stay
+#' # will have 2 or more paths
+#' otherLib <- file.path(td, "newProjectLib")
+#' setLibPaths(otherLib, standAlone = FALSE)
+#' # Can restart R, and changes will stay
 #'
-#'   # remove the custom .libPaths()
-#'   setLibPaths() # reset to previous; remove from .Rprofile
-#'   # because libPath arg is empty
+#' # remove the custom .libPaths()
+#' setLibPaths() # reset to previous; remove from .Rprofile
+#' # because libPath arg is empty
 #'
-#'   Require:::.cleanup(opts)
-#'   unlink(otherLib, recursive = TRUE)
-#' }
-#' }
+#' Require:::.cleanup(opts)
+#' unlink(otherLib, recursive = TRUE)
 #'
 setLibPaths <- function(libPaths, standAlone = TRUE,
                         updateRprofile = getOption("Require.updateRprofile", FALSE),

--- a/man/Require.Rd
+++ b/man/Require.Rd
@@ -238,7 +238,7 @@ will reuse them if needed. To turn off this feature, set
 }
 
 \examples{
-\dontrun{
+\dontshow{if (Require:::.runLongExamples()) withAutoprint(\{ # examplesIf}
 opts <- Require:::.setupExample()
 
 library(Require)
@@ -249,54 +249,51 @@ Require("utils") # analogous to require(stats), but it checks for
 # unquoted version
 Require(c(tools, utils))
 
-if (Require:::.runLongExamples()) {
-  # Install in a new local library (libPaths)
-  tempPkgFolder <- file.path(tempdir(), "Require/Packages")
-  # use standAlone, means it will put it in libPaths, even if it already exists
-  #   in another local library (e.g., personal library)
-  Install("crayon", libPaths = tempPkgFolder, standAlone = TRUE)
+# Install in a new local library (libPaths)
+tempPkgFolder <- file.path(tempdir(), "Require/Packages")
+# use standAlone, means it will put it in libPaths, even if it already exists
+#   in another local library (e.g., personal library)
+Install("crayon", libPaths = tempPkgFolder, standAlone = TRUE)
 
-  # Mutual dependencies, only installs once -- e.g., cli
-  tempPkgFolder <- file.path(tempdir(), "Require/Packages")
-  Install(c("cli", "R6"), libPaths = tempPkgFolder, standAlone = TRUE)
+# Mutual dependencies, only installs once -- e.g., cli
+tempPkgFolder <- file.path(tempdir(), "Require/Packages")
+Install(c("cli", "R6"), libPaths = tempPkgFolder, standAlone = TRUE)
 
-  # Mutual dependencies, only installs once -- e.g., rlang
-  tempPkgFolder <- file.path(tempdir(), "Require/Packages")
-  Install(c("rlang", "ellipsis"), libPaths = tempPkgFolder, standAlone = TRUE)
+# Mutual dependencies, only installs once -- e.g., rlang
+tempPkgFolder <- file.path(tempdir(), "Require/Packages")
+Install(c("rlang", "ellipsis"), libPaths = tempPkgFolder, standAlone = TRUE)
 
-  #####################################################################################
-  # Isolated projects -- Use a project folder and pass to libPaths or set .libPaths() #
-  #####################################################################################
-  # GitHub packages
-  if (requireNamespace("gitcreds", quietly = TRUE)) {
-    # if (is(try(gitcreds::gitcreds_get(), silent = TRUE), "gitcreds")) {
-    ProjectPackageFolder <- file.path(tempdir(), "Require/ProjectA")
-    if (requireNamespace("curl")) {
-      Require("PredictiveEcology/fpCompare@development",
-        libPaths = ProjectPackageFolder,
-      )
-    }
-
-    # No install because it is there already
-    Install("PredictiveEcology/fpCompare@development",
+#####################################################################################
+# Isolated projects -- Use a project folder and pass to libPaths or set .libPaths() #
+#####################################################################################
+# GitHub packages
+if (requireNamespace("gitcreds", quietly = TRUE)) {
+  # if (is(try(gitcreds::gitcreds_get(), silent = TRUE), "gitcreds")) {
+  ProjectPackageFolder <- file.path(tempdir(), "Require/ProjectA")
+  if (requireNamespace("curl")) {
+    Require("PredictiveEcology/fpCompare@development",
       libPaths = ProjectPackageFolder,
-    ) # the latest version on GitHub
-
-    ############################################################################
-    # Mixing and matching GitHub, CRAN, with and without version numbering
-    ############################################################################
-    pkgs <- c(
-      "remotes (<=2.4.1)", # old version
-      "digest (>= 0.6.28)", # recent version
-      "PredictiveEcology/fpCompare@a0260b8476b06628bba0ae73af3430cce9620ca0" # exact version
     )
-    Require::Require(pkgs, libPaths = ProjectPackageFolder)
-    # }
   }
-  Require:::.cleanup(opts)
-}
-}
 
+  # No install because it is there already
+  Install("PredictiveEcology/fpCompare@development",
+    libPaths = ProjectPackageFolder,
+  ) # the latest version on GitHub
+
+  ############################################################################
+  # Mixing and matching GitHub, CRAN, with and without version numbering
+  ############################################################################
+  pkgs <- c(
+    "remotes (<=2.4.1)", # old version
+    "digest (>= 0.6.28)", # recent version
+    "PredictiveEcology/fpCompare@a0260b8476b06628bba0ae73af3430cce9620ca0" # exact version
+  )
+  Require::Require(pkgs, libPaths = ProjectPackageFolder)
+  # }
+}
+Require:::.cleanup(opts)
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 Useful links:

--- a/man/pkgDep.Rd
+++ b/man/pkgDep.Rd
@@ -216,37 +216,30 @@ does not detect the dependencies of base packages among themselves, \emph{e.g.},
 \code{methods} depends on \code{stats} and \code{graphics}. }
 }
 \examples{
-\dontrun{
-if (Require:::.runLongExamples()) {
-  opts <- Require:::.setupExample()
+\dontshow{if (Require:::.runLongExamples()) withAutoprint(\{ # examplesIf}
+opts <- Require:::.setupExample()
 
-  pkgDepTopoSort(c("Require", "data.table"), reverse = TRUE)
+pkgDepTopoSort(c("Require", "data.table"), reverse = TRUE)
 
-  Require:::.cleanup(opts)
-}
-}
+Require:::.cleanup(opts)
+\dontshow{\}) # examplesIf}
+\dontshow{if (Require:::.runLongExamples()) withAutoprint(\{ # examplesIf}
+opts <- Require:::.setupExample()
 
-\dontrun{
-if (Require:::.runLongExamples()) {
-  opts <- Require:::.setupExample()
+pkgDep2("reproducible")
+# much bigger one
+pkgDep2("tidyverse")
 
-  pkgDep2("reproducible")
-  # much bigger one
-  pkgDep2("tidyverse")
+Require:::.cleanup(opts)
+\dontshow{\}) # examplesIf}
+\dontshow{if (Require:::.runLongExamples()) withAutoprint(\{ # examplesIf}
+opts <- Require:::.setupExample()
 
-  Require:::.cleanup(opts)
-}
-}
-\dontrun{
-if (Require:::.runLongExamples()) {
-  opts <- Require:::.setupExample()
+pkgDep("tidyverse", recursive = TRUE)
 
-  pkgDep("tidyverse", recursive = TRUE)
+# GitHub, local, and CRAN packages
+pkgDep(c("PredictiveEcology/reproducible", "Require", "plyr"))
 
-  # GitHub, local, and CRAN packages
-  pkgDep(c("PredictiveEcology/reproducible", "Require", "plyr"))
-
-  Require:::.cleanup(opts)
-}
-}
+Require:::.cleanup(opts)
+\dontshow{\}) # examplesIf}
 }

--- a/man/pkgDepIfDepRemoved.Rd
+++ b/man/pkgDepIfDepRemoved.Rd
@@ -37,14 +37,11 @@ recursive dependencies would be if a package was removed from the immediate
 dependencies.
 }
 \examples{
-\dontrun{
-if (Require:::.runLongExamples()) {
-  opts <- Require:::.setupExample()
+\dontshow{if (Require:::.runLongExamples()) withAutoprint(\{ # examplesIf}
+opts <- Require:::.setupExample()
 
-  pkgDepIfDepRemoved("reproducible", "data.table")
+pkgDepIfDepRemoved("reproducible", "data.table")
 
-  Require:::.cleanup(opts)
-}
-}
-
+Require:::.cleanup(opts)
+\dontshow{\}) # examplesIf}
 }

--- a/man/pkgSnapshot.Rd
+++ b/man/pkgSnapshot.Rd
@@ -216,40 +216,37 @@ Default 50 (stays under macOS's ~256 file-descriptor ulimit).}
 }
 
 \examples{
-\dontrun{
-if (Require:::.runLongExamples()) {
-  opts <- Require:::.setupExample()
+\dontshow{if (Require:::.runLongExamples()) withAutoprint(\{ # examplesIf}
+opts <- Require:::.setupExample()
 
-  # install one archived version so that below does something interesting
-  libForThisEx <- tempdir2("Example")
-  Require("crayon (==1.5.1)", libPaths = libForThisEx, require = FALSE)
-  # Normal use -- using the libForThisEx for example;
-  #    normally libPaths would be omitted to get all
-  #    packages in user or project library
-  tf <- tempfile()
+# install one archived version so that below does something interesting
+libForThisEx <- tempdir2("Example")
+Require("crayon (==1.5.1)", libPaths = libForThisEx, require = FALSE)
+# Normal use -- using the libForThisEx for example;
+#    normally libPaths would be omitted to get all
+#    packages in user or project library
+tf <- tempfile()
 
-  # writes to getOption("Require.packageVersionFile")
-  # within project; also returns a vector
-  # of packages with version
-  pkgs <- pkgSnapshot(
-    packageVersionFile = tf,
-    libPaths = libForThisEx, standAlone = TRUE # only this library
-  )
+# writes to getOption("Require.packageVersionFile")
+# within project; also returns a vector
+# of packages with version
+pkgs <- pkgSnapshot(
+  packageVersionFile = tf,
+  libPaths = libForThisEx, standAlone = TRUE # only this library
+)
 
-  # Now move this file to another computer e.g. by committing in git,
-  #   emailing, googledrive
-  #   on next computer/project
-  Require(packageVersionFile = tf, libPaths = libForThisEx)
+# Now move this file to another computer e.g. by committing in git,
+#   emailing, googledrive
+#   on next computer/project
+Require(packageVersionFile = tf, libPaths = libForThisEx)
 
-  # Using pkgSnapshot2 to get the vector of packages and versions
-  pkgs <- pkgSnapshot2(
-    libPaths = libForThisEx, standAlone = TRUE
-  )
-  Install(pkgs) # will install packages from previous line
+# Using pkgSnapshot2 to get the vector of packages and versions
+pkgs <- pkgSnapshot2(
+  libPaths = libForThisEx, standAlone = TRUE
+)
+Install(pkgs) # will install packages from previous line
 
-  Require:::.cleanup(opts)
-  unlink(getOption("Require.packageVersionFile"))
-}
-}
-
+Require:::.cleanup(opts)
+unlink(getOption("Require.packageVersionFile"))
+\dontshow{\}) # examplesIf}
 }

--- a/man/setLibPaths.Rd
+++ b/man/setLibPaths.Rd
@@ -68,31 +68,28 @@ approach that also works is here:
 \url{https://stackoverflow.com/a/36873741/3890027}.
 }
 \examples{
-\dontrun{
-if (Require:::.runLongExamples()) {
-  opts <- Require:::.setupExample()
-  origDir <- setwd(tempdir())
-  td <- tempdir()
-  setLibPaths(td) # set a new R package library locally
-  setLibPaths() # reset it to original
-  setwd(origDir)
-  # Using standAlone = FALSE means that newly installed packages
-  #   will be installed
-  #   in the new package library, but loading packages can come
-  #   from any of the ones listed in .libPaths()
+\dontshow{if (Require:::.runLongExamples()) withAutoprint(\{ # examplesIf}
+opts <- Require:::.setupExample()
+origDir <- setwd(tempdir())
+td <- tempdir()
+setLibPaths(td) # set a new R package library locally
+setLibPaths() # reset it to original
+setwd(origDir)
+# Using standAlone = FALSE means that newly installed packages
+#   will be installed
+#   in the new package library, but loading packages can come
+#   from any of the ones listed in .libPaths()
 
-  # will have 2 or more paths
-  otherLib <- file.path(td, "newProjectLib")
-  setLibPaths(otherLib, standAlone = FALSE)
-  # Can restart R, and changes will stay
+# will have 2 or more paths
+otherLib <- file.path(td, "newProjectLib")
+setLibPaths(otherLib, standAlone = FALSE)
+# Can restart R, and changes will stay
 
-  # remove the custom .libPaths()
-  setLibPaths() # reset to previous; remove from .Rprofile
-  # because libPath arg is empty
+# remove the custom .libPaths()
+setLibPaths() # reset to previous; remove from .Rprofile
+# because libPath arg is empty
 
-  Require:::.cleanup(opts)
-  unlink(otherLib, recursive = TRUE)
-}
-}
-
+Require:::.cleanup(opts)
+unlink(otherLib, recursive = TRUE)
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,24 +1,3 @@
-## Enable the install-heavy tests for a local manual run.
-##
-## This was keyed on .isDevelVersion(), i.e. a 4-part version like 2.0.0.9036.
-## At a release version (2.1.0 -> 3 parts) it switched off, so test-08, test-09
-## and test-10 went quiet at exactly the commit being released -- the build that
-## most needs them. They reported "empty test" rather than a skip, so the gap
-## was easy to miss.
-##
-## The version was never the right discriminator: those tests already carry
-## skip_on_ci() AND skip_on_cran(), so CI and CRAN exclude themselves. What has
-## to be excluded here is R CMD check, where skip_on_cran() does NOT fire
-## (devtools::check() sets NOT_CRAN = "true") and test-08 alone would install
-## ~100 packages. testthat::is_checking() detects that; it reads
-## TESTTHAT_IS_CHECKING, which testthat sets under R CMD check and not under
-## devtools::test().
-if (nchar(Sys.getenv("R_REQUIRE_RUN_ALL_TESTS")) == 0 &&
-    !testthat::is_checking() &&
-    !isTRUE(as.logical(Sys.getenv("CI")))) {
-  withr::local_envvar(R_REQUIRE_RUN_ALL_TESTS = "true", .local_envir = teardown_env())
-}
-
 ## pak's pkgcache refuses to use the system cache during R CMD check (CRAN
 ## policy: pkgcache aborts with "R_USER_CACHE_DIR env var not set during
 ## package check"). Without this, every pak::pak() call inside the test suite
@@ -59,21 +38,40 @@ usePkgCache <- tempdir2("RequireCacheForTests") # or NULL for using default
 ##    occasionally hung indefinitely on cold pak/pkgcache state — the same
 ##    hang we observed in the 6-hour CI matrix timeouts.
 
-isDev <- Sys.getenv("R_REQUIRE_RUN_ALL_TESTS") == "true" &&
-  Sys.getenv("R_REQUIRE_CHECK_AS_CRAN") != "true"
+## Named for exactly what it is. It mirrors testthat's own two gates and
+## derives from nothing else, so there is no separate switch to maintain and
+## nothing that can disagree with skip_on_cran() / skip_on_ci():
+##
+##   on_cran <- function() {
+##     env <- Sys.getenv("NOT_CRAN")
+##     if (identical(env, "")) !interactive() else !isTRUE(as.logical(env))
+##   }
+##   on_ci <- function() env_var_is_true("CI")
+##
+## This encodes the three contexts the suite actually has: a local run gets
+## everything, CI gets what its skip_on_ci() calls allow, and CRAN gets the
+## small tests. The previous name (`notOnCranOrCI`) was keyed on the package version,
+## which switched off at a release version -- silently, at the one commit that
+## most needed the tests.
+notOnCranOrCI <- local({
+  notCran <- Sys.getenv("NOT_CRAN")
+  notOnCran <- if (identical(notCran, "")) interactive() else isTRUE(as.logical(notCran))
+  notOnCran && !isTRUE(as.logical(Sys.getenv("CI")))
+})
 ## Actually interactive
-isDevAndInteractive <- interactive() && isDev && Sys.getenv("R_REQUIRE_TEST_AS_INTERACTIVE") != "false"
+notOnCranOrCIInteractive <- interactive() && notOnCranOrCI &&
+  Sys.getenv("R_REQUIRE_TEST_AS_INTERACTIVE") != "false"
 
 # try(rm(getFromCache1, getDeps1, getDepsFromCache1), silent = TRUE); i <- 0
 withr::local_options(
   .new = list(
     Require.usePak = Require.usePak,
-    Require.verbose = ifelse(isDev, verboseForDev, -2)
+    Require.verbose = ifelse(notOnCranOrCI, verboseForDev, -2)
   ),
   .local_envir = teardown_env()
 )
 
-if (!isDevAndInteractive) { # i.e., CRAN
+if (!notOnCranOrCIInteractive) { # i.e., CRAN
   withr::local_envvar(# R_REQUIRE_PKG_CACHE = "FALSE",
                       .local_envir = teardown_env())
 }
@@ -109,8 +107,8 @@ withr::local_options(
   .new = list(
     repos = getCRANrepos(ind = 1),
     Ncpus = 2,
-    Require.isDev = isDev,
-    Require.isDevAndInteractive = isDevAndInteractive,
+    Require.notOnCranOrCI = notOnCranOrCI,
+    Require.notOnCranOrCIInteractive = notOnCranOrCIInteractive,
     install.packages.check.source = "never",
     install.packages.compile.from.source = "never",
     Require.unloadNamespaces = TRUE,
@@ -123,7 +121,7 @@ withr::local_options(
     ## any *direct* cli use in Require / our test code; the
     ## R_CLI_DYNAMIC env var (in local_envvar below) carries this
     ## into subprocesses.
-    cli.dynamic = if (isDevAndInteractive) TRUE else NULL,
+    cli.dynamic = if (notOnCranOrCIInteractive) TRUE else NULL,
     ## pak vendors its own progress renderer that ignores cli.dynamic.
     ## Even with the option set, pak's pkgdepends progress bar emits
     ## its spinner ticks as separate lines under testthat's sink.
@@ -131,7 +129,7 @@ withr::local_options(
     ## informational headers ("Will install N packages", "✔ Installed
     ## X") and the per-package install confirmations, just no spinner
     ## storm. Same logic as cli.dynamic: only during interactive dev.
-    pkg.show_progress = if (isDevAndInteractive) FALSE else NULL
+    pkg.show_progress = if (notOnCranOrCIInteractive) FALSE else NULL
   ),
   .local_envir = teardown_env()
 )
@@ -149,7 +147,7 @@ withr::local_envvar(
     ## is_dynamic_tty() reads R_CLI_DYNAMIC after getOption("cli.dynamic")
     ## but before isatty(). Empty string (NA via setting NA) leaves it
     ## untouched in CI / R CMD check.
-    "R_CLI_DYNAMIC" = if (isDevAndInteractive) "true" else NA
+    "R_CLI_DYNAMIC" = if (notOnCranOrCIInteractive) "true" else NA
   ),
   .local_envir = teardown_env()
 )

--- a/tests/testthat/test-00pkgSnapshot_testthat.R
+++ b/tests/testthat/test-00pkgSnapshot_testthat.R
@@ -2,7 +2,7 @@ test_that("test 1", {
   setupInitial <- setupTest()
   # on.exit(endTest(setupInitial))
 
-  isDev <- getOption("Require.isDev")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
 
   quiet <- !(getOption("Require.verbose") >= 1)
 
@@ -18,7 +18,7 @@ test_that("test 1", {
 
   setLibPaths(tmpdir2, standAlone = TRUE)
   tmpdir2Actual <- .libPaths()[1] # setLibPaths postpends the R version
-  if (isDev) {
+  if (notOnCranOrCI) {
     ## Bumped from covr (==3.6.3) to covr (==3.6.5):
     ## covr 3.6.3 used the SET_BODY symbol from R-internals which was
     ## removed in R 4.5+. R CMD INSTALL of covr 3.6.3 builds fine but

--- a/tests/testthat/test-01packages_testthat.R
+++ b/tests/testthat/test-01packages_testthat.R
@@ -13,7 +13,7 @@ test_that("test 1", {
   setupInitial <- setupTest()
   # on.exit(endTest(setupInitial))
 
-  isDev <- getOption("Require.isDev")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
 
   ## cover CRAN in case of having a environment variable set, which CI seems to
   origCRAN_REPO <- Sys.getenv("CRAN_REPO")
@@ -89,7 +89,7 @@ test_that("test 1", {
 
   # Try older version
   if (identical(tolower(Sys.getenv("CI")), "true") || # travis
-      isDevAndInteractive || # interactive
+      notOnCranOrCIInteractive || # interactive
       identical(Sys.getenv("NOT_CRAN"), "true")) { # CTRL-SHIFT-E
     dir2 <- rpackageFolder(tempdir3())
     dir2 <- checkPath(dir2, create = TRUE)
@@ -261,7 +261,7 @@ test_that("test 1", {
 
   # Code coverage
   skip_on_cran()
-  # if (isDev) { # i.e., GA, R CMD check etc.
+  # if (notOnCranOrCI) { # i.e., GA, R CMD check etc.
 
   # Issue 87
   try(remove.packages("reproducible"), silent = TRUE) |> suppressMessages()
@@ -377,7 +377,7 @@ test_that("test 1", {
   # warn <- tryCatch(out <- Require("Require (>=0.0.1)", dependencies = FALSE,
   #                                 install = "force"),
   #                  error = function(x) x)
-  if (isDevAndInteractive) {
+  if (notOnCranOrCIInteractive) {
     warn <- tryCatch(
       {
         out <- Require("A3 (<=0.0.1)", dependencies = FALSE, install = "force")

--- a/tests/testthat/test-02extract_testthat.R
+++ b/tests/testthat/test-02extract_testthat.R
@@ -3,7 +3,7 @@ test_that("test 1", {
   setupInitial <- setupTest()
   # on.exit(endTest(setupInitial))
 
-  isDev <- getOption("Require.isDev")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
 
   a <- extractPkgName("Require (>=0.0.1)")
   testthat::expect_true({

--- a/tests/testthat/test-03helpers_testthat.R
+++ b/tests/testthat/test-03helpers_testthat.R
@@ -3,7 +3,7 @@ test_that("test 3", {
   setupInitial <- setupTest()
     # on.exit(endTest(setupInitial))
 
-  isDev <- getOption("Require.isDev")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
 
   out <- utils::capture.output(type = "message", Require:::messageDF(cbind(a = 1.1232),
                                                                      round = 2,

--- a/tests/testthat/test-04other_testthat.R
+++ b/tests/testthat/test-04other_testthat.R
@@ -10,7 +10,7 @@ test_that("test 4", {
   setupInitial <- setupTest()
   # on.exit(endTest(setupInitial))
 
-  isDev <- getOption("Require.isDev")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
   # Test misspelled
 
   warns <- capture_warnings(
@@ -42,13 +42,13 @@ test_that("test 4", {
 
 
   pkgDep("data.table", purge = FALSE)
-  if (!isDev) {
+  if (!notOnCranOrCI) {
     pkgDep("data.table", purge = TRUE)
   }
 
   skip_if_offline2()
   if (isTRUE(tryCatch(packageVersion("fpCompare"), error = function(e) "0.0.0") < "0.2.5")) {
-    if (isDev) {
+    if (notOnCranOrCI) {
       mess <- capture_messages(
         warns <- capture_warnings(
           Require::Install(c("fpCompare (>= 0.2.4)", "PredictiveEcology/fpCompare@development (>= 0.2.4.9000)"),
@@ -204,7 +204,7 @@ test_that("test 4", {
     testArgs <- setdiff(testArgs, c("roxygen2", "rmarkdown", "fpCompare", "pkgcache"))
     testthat::expect_identical(testArgs, character())
   }
-  if (isDev) {
+  if (notOnCranOrCI) {
     # this was a bug created a warning when there was a package not on CRAN, but there
     #   were multiple repos; ffbase is no longer on CRAN
     # can't quiet this down on linux because ffbase is not binary but rest are ...

--- a/tests/testthat/test-05packagesLong_testthat.R
+++ b/tests/testthat/test-05packagesLong_testthat.R
@@ -5,10 +5,10 @@ test_that("test 5", {
   setupInitial <- setupTest()
   # on.exit(endTest(setupInitial))
 
-  # isDev <- getOption("Require.isDev")
-  # isDevAndInteractive <- getOption("Require.isDevAndInteractive")
+  # notOnCranOrCI <- getOption("Require.notOnCranOrCI")
+  # notOnCranOrCIInteractive <- getOption("Require.notOnCranOrCIInteractive")
 
-  # if (isDevAndInteractive) {
+  # if (notOnCranOrCIInteractive) {
   tmpdir <- file.path(tempdir2(paste0("RequireTmp", sample(1e5, 1))))
 
   dir.create(tmpdir, showWarnings = FALSE, recursive = TRUE)

--- a/tests/testthat/test-06pkgDep_testthat.R
+++ b/tests/testthat/test-06pkgDep_testthat.R
@@ -5,8 +5,8 @@ test_that("test 6", {
   tmpdir <- tempdir2(.rndstr())
   .libPaths(tmpdir)
 
-  isDev <- getOption("Require.isDev")
-  # isDevAndInteractive <- getOption("Require.isDevAndInteractive")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
+  # notOnCranOrCIInteractive <- getOption("Require.notOnCranOrCIInteractive")
 
   a <- pkgDep("Require", recursive = TRUE)
   testthat::expect_true({
@@ -176,7 +176,7 @@ test_that("test 6", {
     knownRevDeps[[p]][!knownRevDeps[[p]] %in% out[[p]]]
   }))
 
-  # if (isDev) {
+  # if (notOnCranOrCI) {
   testthat::expect_true({
     length(test) == 0
   })

--- a/tests/testthat/test-06pkgDep_testthat.R
+++ b/tests/testthat/test-06pkgDep_testthat.R
@@ -128,7 +128,10 @@ test_that("test 6", {
 
   # MUST HAVE the "knownRevDeps" installed first
   skip_on_cran()
-  skip_on_ci()
+  # pkgDepTopoSort below force-installs Require from GitHub: measured 626s
+  # (10.4 min) warm-cache locally, more on a cold runner. Too heavy for all
+  # 11 matrix entries; runs on the single `runLong: true` entry instead.
+  if (!nzchar(Sys.getenv("R_REQUIRE_RUN_LONG_CI"))) skip_on_ci()
   knownRevDeps <- list(
     Require = c(
       # "reproducible",

--- a/tests/testthat/test-08modules_testthat.R
+++ b/tests/testthat/test-08modules_testthat.R
@@ -3,12 +3,12 @@ test_that("test 8", {
   # skip_if(getOption("Require.usePak"), message = "Not an option on usePak = TRUE")
   setupInitial <- setupTest()
 
-  isDev <- getOption("Require.isDev")
-  isDevAndInteractive <- getOption("Require.isDevAndInteractive")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
+  notOnCranOrCIInteractive <- getOption("Require.notOnCranOrCIInteractive")
 
   # Skip on CI: this test installs ~100 packages (incl. heavy LandR/SpaDES
   # transitive dep tree) which routinely takes >2h on GH-hosted runners and
-  # times out. Runs locally for devs via R_REQUIRE_RUN_ALL_TESTS=true.
+  # times out. Runs locally for devs, where NOT_CRAN=true.
   skip_on_ci()
   # Same rationale applies to CRAN's check farm: 100+ source compiles leave
   # gcc `.s` intermediates in /tmp which trip the "detritus in the temp
@@ -16,7 +16,7 @@ test_that("test 8", {
   # check budget. This is a developer-only end-to-end test, not a Require
   # behaviour test that CRAN needs to run.
   skip_on_cran()
-  if (isDev) {
+  if (notOnCranOrCI) {
     projectDir <- Require:::tempdir2(Require:::.rndstr(1))
     # setLinuxBinaryRepo()
     pkgDir <- file.path(projectDir, "R")

--- a/tests/testthat/test-09pkgSnapshotLong_testthat.R
+++ b/tests/testthat/test-09pkgSnapshotLong_testthat.R
@@ -1,8 +1,8 @@
 test_that("test 09", {
 
   # 380-pkg snapshot install + recursive pkgDep takes >1h end-to-end on
-  # a 30-pkg slice profile -- way past CI budget. Run locally only via
-  # R_REQUIRE_RUN_ALL_TESTS=true.
+  # a 30-pkg slice profile -- way past CI budget. Runs locally only,
+  # where NOT_CRAN=true.
   skip_on_ci()
   # The snapshot-vs-installed-version assertion compares the pinned versions
   # in inst/snapshot.txt against installed.packages() in the system library.
@@ -16,8 +16,8 @@ test_that("test 09", {
   setupInitial <- setupTest(needRequireInNewLib = FALSE)
   # on.exit(endTest(setupInitial))
 
-  isDev <- getOption("Require.isDev")
-  isDevAndInteractive <- getOption("Require.isDevAndInteractive")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
+  notOnCranOrCIInteractive <- getOption("Require.notOnCranOrCIInteractive")
 
   skip_if_offline2()
 

--- a/tests/testthat/test-10DifferentPkgs_testthat.R
+++ b/tests/testthat/test-10DifferentPkgs_testthat.R
@@ -2,15 +2,15 @@ test_that("test 10", {
   setupInitial <- setupTest(needRequireInNewLib = TRUE)
   # on.exit(endTest(setupInitial))
 
-  isDev <- getOption("Require.isDev")
-  isDevAndInteractive <- getOption("Require.isDevAndInteractive")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
+  notOnCranOrCIInteractive <- getOption("Require.notOnCranOrCIInteractive")
   # Skip on CI: installs bcgov/climr + tidymodels + ccissr — heavy GitHub
-  # cascades that exceed CI budgets. Runs locally for devs via
-  # R_REQUIRE_RUN_ALL_TESTS=true. Same rationale applies to CRAN's check
+  # cascades that exceed CI budgets. Runs locally for devs, where
+  # NOT_CRAN=true. Same rationale applies to CRAN's check
   # farm (install budget + risk of detritus from source compiles).
   skip_on_cran()
   skip_on_ci()
-  if (isDev) {
+  if (notOnCranOrCI) {
     # 4.3.0 doesn't have binaries, and historical versions of spatial packages won't compile
     pkgs <- c('reproducible',
               'SpaDES.core (>= 2.0.3)',

--- a/tests/testthat/test-11misc_testthat.R
+++ b/tests/testthat/test-11misc_testthat.R
@@ -25,10 +25,10 @@ test_that("test 11", {
                 info = paste("warns =", paste(warns, collapse = " | ")))
   }
 
-  isDev <- getOption("Require.isDev")
-  isDevAndInteractive <- getOption("Require.isDevAndInteractive")
+  notOnCranOrCI <- getOption("Require.notOnCranOrCI")
+  notOnCranOrCIInteractive <- getOption("Require.notOnCranOrCIInteractive")
 
-  if (isDevAndInteractive) {
+  if (notOnCranOrCIInteractive) {
     # Use a mixture of different types of "off CRAN"
     if (!isMacOS()) {
       pkgs <- c("knn", "ggplot2 (==3.4.3)", "silly1", "SpaDES.core")

--- a/tests/testthat/test-16installFailureMetadata_testthat.R
+++ b/tests/testthat/test-16installFailureMetadata_testthat.R
@@ -445,7 +445,6 @@ test_that("pakGetArchive constructs CRAN-archive URL for archived package", {
   # round-trip (which exercises the archive fallback path inside
   # pakInstallFiltered) is environment-sensitive and runs in the larger
   # integration test below.
-  if (!nzchar(Sys.getenv("R_REQUIRE_RUN_LONG_CI"))) skip_on_ci()
   skip_on_cran()
   skip_if_offline2()
   skip_if_not_installed("pak")
@@ -469,7 +468,6 @@ test_that("pakGetArchive constructs CRAN-archive URL for archived package", {
 # so the caller can skip cleanly.
 # ---------------------------------------------------------------------------
 test_that("pakGetArchive returns unchanged packages when no concrete CRAN repo", {
-  if (!nzchar(Sys.getenv("R_REQUIRE_RUN_LONG_CI"))) skip_on_ci()
   skip_on_cran()
   skip_if_offline2()
   skip_if_not_installed("pak")
@@ -582,7 +580,6 @@ test_that("pak::pak installs cross-dependent archived refs in one batch", {
 # in pakEnv()$.lastInstallFailures.
 # ---------------------------------------------------------------------------
 test_that("pakEnv()$.lastInstallFailures is populated after a successful install", {
-  if (!nzchar(Sys.getenv("R_REQUIRE_RUN_LONG_CI"))) skip_on_ci()
   skip_on_cran()
   skip_if_offline2()
   skip_if_not_installed("pak")
@@ -636,7 +633,7 @@ test_that("pakEnv()$.lastInstallFailures is populated after a successful install
 # ---------------------------------------------------------------------------
 test_that("identify-and-defer recovers from PSPclean-style cascade", {
   skip_on_cran()
-  skip_on_ci()
+  if (!nzchar(Sys.getenv("R_REQUIRE_RUN_LONG_CI"))) skip_on_ci()
   skip_if_offline2()
   skip_if_not_installed("pak")
   if (identical(tolower(Sys.getenv("R_REQUIRE_RUN_LARGE_INTEGRATION", "true")),


### PR DESCRIPTION
Three related changes. `R CMD check --as-cran`: **Status: OK**, `FAIL 0 | WARN 0 | SKIP 21 | PASS 625`, `checking examples ... OK`.

## 1. `isDev` -> `notOnCranOrCI`

`isDev` was keyed on the package version (a 4-part version like `2.0.0.9036`), so it switched off at a release version — silently, at the one commit that most needs the install-heavy tests. It was a second switch that could disagree with `skip_on_cran()` / `skip_on_ci()`, and it had to be maintained by hand.

It now derives from nothing but the env vars testthat itself reads, and is named for what it is:

```r
notOnCranOrCI <- local({
  notCran <- Sys.getenv("NOT_CRAN")
  notOnCran <- if (identical(notCran, "")) interactive() else isTRUE(as.logical(notCran))
  notOnCran && !isTRUE(as.logical(Sys.getenv("CI")))
})
```

Verified identical to `!on_cran() && !on_ci()` across all six `NOT_CRAN` x `CI` combinations, malformed values included. Renamed in 12 files, options included.

Also drops what this orphaned: the `R_REQUIRE_RUN_ALL_TESTS` block in `setup.R` and `R_REQUIRE_CHECK_AS_CRAN` (one line, one reader).

**Behaviour note:** local `devtools::check()` sets `NOT_CRAN=true`, so heavy branches now run under R CMD check locally. Real `R CMD check --as-cran` on the tarball does not set it, so CRAN still gets the small tests.

## 2. Dead helpers removed; examples use `@examplesIf`

`.isDevelVersion()` and `.runLongTests()` were reachable from nothing once the gate stopped using the package version.

`.isDevelVersion()` carried `@importFrom utils packageDescription`, but `packageDescription()` is still used by `RequireDependencies()` in `pkgDep3.R` — deleting the function with its roxygen block would have dropped the import from NAMESPACE and broken that call at runtime. The tag moved to the function that uses it; NAMESPACE regenerates **byte-identical**.

`.runLongExamples()` stays — it is the condition in seven documented functions, which now use `@examplesIf` instead of hand-rolled `\dontrun{ if (...) { ... } }` nesting. Example **code** is byte-identical across all regenerated `.Rd` files after normalising wrappers and indentation.

## 3. CI gates set from measurements

Every `skip_on_ci()` was measured rather than assumed.

Ungated — all 11 entries, and now counted in coverage (the coverage job runs with `CI=true`, so these were excluded from the reported figure even though the runLong entry ran them):

| test | measured |
|---|---|
| `pakGetArchive constructs CRAN-archive URL` | 1.7s (installs nothing) |
| `pakGetArchive returns unchanged packages` | 0.5s (installs nothing) |
| `pakEnv()$.lastInstallFailures is populated` | 3.4s |

Moved onto the single `runLong: true` entry, where they previously ran on **no** CI entry:

| test | measured |
|---|---|
| `identify-and-defer PSPclean-style cascade` | had a bare `skip_on_ci()` |
| test-06 `pkgDepTopoSort` section | 626s (10.4 min) warm-cache |

Unchanged: the two archived-CRAN install round-trips (103s, 20s).

test-06 is why these were measured — at 626s, ungating it outright would have added 10+ minutes to all 11 entries.

Workflow comments corrected: they claimed "5 archived-CRAN install round-trips ... measured at 340s", wrong in both count and figure.