### PR TITLE
fix: don't reinstall packages that are already current

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,20 @@
 
 ## Installation correctness
 
+* `updatePackages()` no longer reinstalls the whole library. It handed every
+  installed package to the installer as `pkg (HEAD)` without comparing against
+  what the repositories offer, so pak planned a same-version rebuild for each
+  (`cli 3.6.6 -> 3.6.6`). Where `base::update.packages()` found three packages
+  needing work, `updatePackages()` asked for a hundred and seventy. GitHub refs
+  are still always resolved -- a branch HEAD moves without the version changing
+  -- as is anything the repositories do not currently offer.
+
+* The pak retry machinery no longer re-attempts a ref that already failed while
+  nothing it depends on has changed, and pins already-installed refs on every
+  pass rather than only the first. A single unbuildable dependency used to make
+  each of the four identify-and-defer phases retry it in turn, rebuilding
+  dozens of already-installed packages each round (#190).
+
 * `options(Require.snapshotInstaller = "install.packages")` now genuinely
   bypasses pak. The option selected which installer function to call, but that
   function's own branches keyed on whether pak was *installed* rather than on

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,13 +34,16 @@
 
 ## Installation correctness
 
-* `updatePackages()` no longer reinstalls the whole library. It handed every
-  installed package to the installer as `pkg (HEAD)` without comparing against
-  what the repositories offer, so pak planned a same-version rebuild for each
-  (`cli 3.6.6 -> 3.6.6`). Where `base::update.packages()` found three packages
-  needing work, `updatePackages()` asked for a hundred and seventy. GitHub refs
-  are still always resolved -- a branch HEAD moves without the version changing
-  -- as is anything the repositories do not currently offer.
+* A `(HEAD)` version spec no longer forces a reinstall of a package that is
+  already current. Any ref carrying `(HEAD)` was marked "installed version not
+  OK" regardless of what was on disk, and the comparison that would have
+  corrected this lives on the legacy non-pak install path, so under the default
+  `Require.usePak = TRUE` it never ran. Since `updatePackages()` tags every
+  installed CRAN package `pkg (HEAD)`, it asked for the entire library back --
+  a hundred and seventy same-version rebuilds where `base::update.packages()`
+  correctly found three. A CRAN-form `(HEAD)` ref is now settled against the
+  version the repositories offer; GitHub refs are unchanged, since a branch
+  HEAD moves without the version changing.
 
 * The pak retry machinery no longer re-attempts a ref that already failed while
   nothing it depends on has changed, and pins already-installed refs on every

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,9 +41,11 @@
   `Require.usePak = TRUE` it never ran. Since `updatePackages()` tags every
   installed CRAN package `pkg (HEAD)`, it asked for the entire library back --
   a hundred and seventy same-version rebuilds where `base::update.packages()`
-  correctly found three. A CRAN-form `(HEAD)` ref is now settled against the
-  version the repositories offer; GitHub refs are unchanged, since a branch
-  HEAD moves without the version changing.
+  correctly found three. `(HEAD)` is now settled per source, as it always
+  meant to be: a CRAN-alike ref against the version the repositories offer, a
+  GitHub ref against the SHA its branch points at. Anything unresolvable -- an
+  unknown version, no installed `DESCRIPTION`, an unreachable GitHub -- still
+  installs, so a network failure is never read as "up to date".
 
 * The pak retry machinery no longer re-attempts a ref that already failed while
   nothing it depends on has changed, and pins already-installed refs on every

--- a/R/Require2.R
+++ b/R/Require2.R
@@ -3059,6 +3059,40 @@ packageFullNameFromSnapshot <- function(snapshot) {
 #' possible state, whether they are on CRAN currently, archived, or on GitHub.
 #' @export
 #'
+# ---------------------------------------------------------------------------
+# .updateIsPossiblyNeeded: which installed packages might have something newer?
+#
+# updatePackages() used to hand Install() every installed package as
+# `pkg (HEAD)`, with no comparison against what the repositories actually
+# offer. pak then planned a reinstall of the whole library, reported as a wall
+# of same-version "updates" (`cli 3.6.6 -> 3.6.6 [bld][cmp]`), and rebuilt
+# packages that were already current. base::update.packages() makes this
+# comparison first, which is why it found three packages needing work where
+# updatePackages() found a hundred and seventy.
+#
+# Returns TRUE for a row that must still be resolved:
+#   * GitHub refs, always -- a branch HEAD moves without the DESCRIPTION
+#     version changing, so there is nothing local to compare against;
+#   * anything the repositories do not currently offer (archived, or a repo
+#     that is momentarily unreachable), since we cannot show it is current;
+#   * CRAN-form refs whose available version is strictly newer than installed.
+#
+# With no usable `ap` this returns all TRUE, i.e. exactly the old behaviour.
+# ---------------------------------------------------------------------------
+.updateIsPossiblyNeeded <- function(pkgNames, instVer, isGH, ap) {
+  n <- length(pkgNames)
+  if (!n) return(logical(0))
+  if (is.null(ap) || !NROW(ap)) return(rep(TRUE, n))
+  m <- match(pkgNames, rownames(ap))
+  availVer <- rep(NA_character_, n)
+  availVer[!is.na(m)] <- ap[m[!is.na(m)], "Version"]
+  isNewer <- vapply(seq_len(n), function(i) {
+    if (is.na(availVer[i]) || is.na(instVer[i])) return(TRUE)
+    utils::compareVersion(availVer[i], instVer[i]) > 0
+  }, logical(1))
+  isGH | isNewer
+}
+
 updatePackages <- function(libPaths = .libPaths()[1], purge = FALSE,
                            verbose = getOption("Require.verbose")) {
 
@@ -3078,6 +3112,26 @@ updatePackages <- function(libPaths = .libPaths()[1], purge = FALSE,
     # github
     paste0(ip[["Package"]], head) # cran
   ))
+
+  ## Ask only for what could actually change; see .updateIsPossiblyNeeded().
+  isGHrow <- !is.na(ip$GithubRepo)
+  ap <- tryCatch(available.packages(repos = getOption("repos")),
+                 error = function(e) NULL)
+  needed <- .updateIsPossiblyNeeded(ip[["Package"]], ip[["Version"]], isGHrow, ap)
+  if (any(!needed)) {
+    messageVerbose(
+      "updatePackages: ", sum(!needed), " of ", length(needed),
+      " installed package(s) are already at the newest version the ",
+      "repositories offer; not reinstalling them",
+      verbose = verbose, verboseLevel = 1)
+    pkgs <- pkgs[needed]
+    ip <- ip[needed]
+  }
+  if (!length(pkgs)) {
+    messageVerbose("updatePackages: nothing to update",
+                   verbose = verbose, verboseLevel = 1)
+    return(invisible(NULL))
+  }
 
   # check for SHAs that need user input to update:
   pkgsSplit <- strsplit(pkgs, split = "@")

--- a/R/Require2.R
+++ b/R/Require2.R
@@ -447,7 +447,7 @@ Require <- function(packages,
         }
       }
       pkgDT <- dealWithStandAlone(pkgDT, libPaths, standAlone)
-      pkgDT <- whichToInstall(pkgDT, install, verbose)
+      pkgDT <- whichToInstall(pkgDT, install, verbose, libPaths = libPaths)
 
       # If a candidate is already loaded in this session with a version that
       # satisfies the constraint, skip reinstall -- both to avoid pak's
@@ -1096,7 +1096,7 @@ archivedOn <- function(possiblyArchivedPkg, pkgRelPath, verbose, repos, numGroup
   )
 }
 
-whichToInstall <- function(pkgDT, install, verbose) {
+whichToInstall <- function(pkgDT, install, verbose, libPaths = .libPaths()) {
   set(pkgDT, NULL, "isPkgInstalled", !is.na(pkgDT[["Version"]]))
   set(pkgDT, NULL, "installedVersionOK", !is.na(pkgDT[["Version"]])) # default: if it is installed,  say "OK"
   if (!is.null(pkgDT[[hasHEADtxt]])) {
@@ -1137,14 +1137,43 @@ whichToInstall <- function(pkgDT, install, verbose) {
     isGHrow <- if (is.null(pkgDT[["repoLocation"]])) rep(TRUE, length(whHEAD))
                else pkgDT[["repoLocation"]][whHEAD] %in% .txtGitHub
     ok <- rep(FALSE, length(whHEAD))
+
+    ## CRAN-alike half: newest the repositories offer, by version.
     vor <- pkgDT[["VersionOnRepos"]]
     if (!is.null(vor)) {
       instV <- pkgDT[["Version"]][whHEAD]
       availV <- vor[whHEAD]
-      ## Only a CRAN-form row with both versions known can be settled; a
-      ## missing version leaves ok = FALSE, i.e. the old "install" answer.
       cmp <- which(!isGHrow & !is.na(instV) & !is.na(availV))
       for (k in cmp) ok[k] <- utils::compareVersion(instV[k], availV[k]) >= 0
+    }
+
+    ## GitHub half: newest the branch points at, by SHA. Reuses
+    ## alreadyExistingDESCFile(), which is the existing implementation of this
+    ## question -- it reads GithubSHA1 out of the installed DESCRIPTION and
+    ## compares it with getSHAfromGitHubMemoise(). doDownloads() calls the same
+    ## machinery, but it sits on the legacy non-pak path, so under the default
+    ## Require.usePak = TRUE nothing compared SHAs and every GitHub HEAD ref
+    ## reinstalled unconditionally. Reading the SHA from disk means this does
+    ## not depend on pkgDT carrying a local-SHA column.
+    haveGHcols <- all(c("Account", "Repo", "Branch") %in% colnames(pkgDT))
+    if (any(isGHrow) && haveGHcols) {
+      acct <- pkgDT[["Account"]][whHEAD]
+      repo <- pkgDT[["Repo"]][whHEAD]
+      br <- pkgDT[["Branch"]][whHEAD]
+      gh <- which(isGHrow & !is.na(acct) & !is.na(repo) & !is.na(br))
+      for (k in gh) {
+        ## Anything unresolvable -- no local DESCRIPTION, unreachable GitHub --
+        ## leaves ok = FALSE, i.e. the old "install" answer. A network failure
+        ## must never read as "you are up to date".
+        res <- tryCatch(
+          alreadyExistingDESCFile(libPaths = libPaths, Repo = repo[k],
+                                  Account = acct[k], Branch = br[k],
+                                  installResult = NA_character_,
+                                  verbose = verbose),
+          error = function(e) NULL)
+        if (!is.null(res))
+          ok[k] <- identical(res[[3]], .txtShaUnchangedNoInstall)
+      }
     }
     set(pkgDT, whHEAD, "installedVersionOK", ok)
   }

--- a/R/Require2.R
+++ b/R/Require2.R
@@ -1116,7 +1116,37 @@ whichToInstall <- function(pkgDT, install, verbose) {
 
   pkgDT <- checkHEAD(pkgDT)
   if (any(pkgDT[[hasHEADtxt]])) {
-    set(pkgDT, which(pkgDT[[hasHEADtxt]]), "installedVersionOK", FALSE)
+    ## A `(HEAD)` ref used to force installedVersionOK = FALSE on every row
+    ## carrying it -- "always install", whatever is on disk.
+    ##
+    ## For a GitHub ref that is right: a branch HEAD moves without the
+    ## DESCRIPTION version changing, so only a SHA comparison can settle it.
+    ## For a CRAN-form ref, "HEAD" just means "the newest the repositories
+    ## have", which we can settle here from metadata already in hand. Nothing
+    ## downstream did it: the HEAD -> dontInstall comparison lives in
+    ## doDownloads(), reachable only from doInstalls(), which is the `else`
+    ## branch of `if (getOption("Require.usePak"))`. Under the default
+    ## usePak = TRUE it never ran.
+    ##
+    ## That mattered because updatePackages() tags every installed CRAN
+    ## package `pkg (HEAD)`, so Install() was being asked to reinstall the
+    ## whole library -- 170 same-version rebuilds where update.packages()
+    ## correctly found 3. Install() not reinstalling what you already have is
+    ## the point of the package, so the fix belongs here, not in the caller.
+    whHEAD <- which(pkgDT[[hasHEADtxt]] %in% TRUE)
+    isGHrow <- if (is.null(pkgDT[["repoLocation"]])) rep(TRUE, length(whHEAD))
+               else pkgDT[["repoLocation"]][whHEAD] %in% .txtGitHub
+    ok <- rep(FALSE, length(whHEAD))
+    vor <- pkgDT[["VersionOnRepos"]]
+    if (!is.null(vor)) {
+      instV <- pkgDT[["Version"]][whHEAD]
+      availV <- vor[whHEAD]
+      ## Only a CRAN-form row with both versions known can be settled; a
+      ## missing version leaves ok = FALSE, i.e. the old "install" answer.
+      cmp <- which(!isGHrow & !is.na(instV) & !is.na(availV))
+      for (k in cmp) ok[k] <- utils::compareVersion(instV[k], availV[k]) >= 0
+    }
+    set(pkgDT, whHEAD, "installedVersionOK", ok)
   }
 
   set(pkgDT, NULL, "needInstall", c(.txtDontInstall, .txtInstall)[pkgDT$installedVersionOK %in% FALSE + 1])
@@ -3059,40 +3089,6 @@ packageFullNameFromSnapshot <- function(snapshot) {
 #' possible state, whether they are on CRAN currently, archived, or on GitHub.
 #' @export
 #'
-# ---------------------------------------------------------------------------
-# .updateIsPossiblyNeeded: which installed packages might have something newer?
-#
-# updatePackages() used to hand Install() every installed package as
-# `pkg (HEAD)`, with no comparison against what the repositories actually
-# offer. pak then planned a reinstall of the whole library, reported as a wall
-# of same-version "updates" (`cli 3.6.6 -> 3.6.6 [bld][cmp]`), and rebuilt
-# packages that were already current. base::update.packages() makes this
-# comparison first, which is why it found three packages needing work where
-# updatePackages() found a hundred and seventy.
-#
-# Returns TRUE for a row that must still be resolved:
-#   * GitHub refs, always -- a branch HEAD moves without the DESCRIPTION
-#     version changing, so there is nothing local to compare against;
-#   * anything the repositories do not currently offer (archived, or a repo
-#     that is momentarily unreachable), since we cannot show it is current;
-#   * CRAN-form refs whose available version is strictly newer than installed.
-#
-# With no usable `ap` this returns all TRUE, i.e. exactly the old behaviour.
-# ---------------------------------------------------------------------------
-.updateIsPossiblyNeeded <- function(pkgNames, instVer, isGH, ap) {
-  n <- length(pkgNames)
-  if (!n) return(logical(0))
-  if (is.null(ap) || !NROW(ap)) return(rep(TRUE, n))
-  m <- match(pkgNames, rownames(ap))
-  availVer <- rep(NA_character_, n)
-  availVer[!is.na(m)] <- ap[m[!is.na(m)], "Version"]
-  isNewer <- vapply(seq_len(n), function(i) {
-    if (is.na(availVer[i]) || is.na(instVer[i])) return(TRUE)
-    utils::compareVersion(availVer[i], instVer[i]) > 0
-  }, logical(1))
-  isGH | isNewer
-}
-
 updatePackages <- function(libPaths = .libPaths()[1], purge = FALSE,
                            verbose = getOption("Require.verbose")) {
 
@@ -3112,26 +3108,6 @@ updatePackages <- function(libPaths = .libPaths()[1], purge = FALSE,
     # github
     paste0(ip[["Package"]], head) # cran
   ))
-
-  ## Ask only for what could actually change; see .updateIsPossiblyNeeded().
-  isGHrow <- !is.na(ip$GithubRepo)
-  ap <- tryCatch(available.packages(repos = getOption("repos")),
-                 error = function(e) NULL)
-  needed <- .updateIsPossiblyNeeded(ip[["Package"]], ip[["Version"]], isGHrow, ap)
-  if (any(!needed)) {
-    messageVerbose(
-      "updatePackages: ", sum(!needed), " of ", length(needed),
-      " installed package(s) are already at the newest version the ",
-      "repositories offer; not reinstalling them",
-      verbose = verbose, verboseLevel = 1)
-    pkgs <- pkgs[needed]
-    ip <- ip[needed]
-  }
-  if (!length(pkgs)) {
-    messageVerbose("updatePackages: nothing to update",
-                   verbose = verbose, verboseLevel = 1)
-    return(invisible(NULL))
-  }
 
   # check for SHAs that need user input to update:
   pkgsSplit <- strsplit(pkgs, split = "@")

--- a/R/pak.R
+++ b/R/pak.R
@@ -4004,7 +4004,14 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
         error = function(e) character(0))
       deferred <- .pakDropUnchangedFailures(failMemo, deferred,
                                             instBeforeDeferred, verbose)
-      if (!length(deferred)) break
+    }
+    ## Re-test: .pakDropUnchangedFailures() above can empty `deferred`, and the
+    ## serial pass and its retries below must then be skipped. This was a
+    ## `break`, which R CMD check rightly flagged -- "break used in wrong
+    ## context: no loop is visible" -- because the enclosing block is an `if`,
+    ## not a loop. That WARNING failed every R-CMD-check job while the tests
+    ## themselves passed.
+    if (length(deferred)) {
       .pakRecordFailures(failMemo, deferred, instBeforeDeferred)
       messageVerbose(
         "identify-and-defer: installing ", length(deferred),

--- a/R/pak.R
+++ b/R/pak.R
@@ -3217,8 +3217,58 @@ pakResetSubprocess <- function() {
 # upgrade = FALSE for CRAN, TRUE for GitHub -- same per-ref policy as the
 # parallel version. Failures are warned but don't abort the loop.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# .pakFailMemo / .pakDropUnchangedFailures: stop re-attempting a ref that
+# already failed while nothing it could depend on has changed.
+#
+# identify-and-defer runs several phases -- the iteration loop, the
+# no-parseable-culprits serial fallback, the deferred-culprit serial pass, and
+# up to three retries after it. Each phase decided independently what to
+# attempt, so a ref that cannot build (e.g. Deriv failing to compile) was
+# handed to pak once per phase, five times in all, every time against an
+# identical set of installed packages. See #190.
+#
+# Retrying is only useful when a dependency has been installed since the last
+# attempt, so the memo keys each failed ref on the installed set at the moment
+# it failed. A ref is dropped only if that set is unchanged; any new package
+# anywhere makes it eligible again, which is deliberately conservative -- we
+# would rather retry once too often than refuse to install something that has
+# just been unblocked.
+# ---------------------------------------------------------------------------
+.pakFailMemo <- function() new.env(parent = emptyenv())
+
+.pakRecordFailures <- function(memo, refs, installedNow) {
+  for (r in refs) assign(r, installedNow, envir = memo)
+  invisible(memo)
+}
+
+.pakDropUnchangedFailures <- function(memo, refs, installedNow, verbose = 0L) {
+  if (!length(refs)) return(refs)
+  keep <- vapply(refs, function(r) {
+    prev <- if (exists(r, envir = memo, inherits = FALSE)) get(r, envir = memo) else NULL
+    is.null(prev) || !identical(sort(prev), sort(installedNow))
+  }, logical(1))
+  if (any(!keep))
+    messageVerbose(
+      "identify-and-defer: skipping ", sum(!keep), " ref(s) that already failed ",
+      "with no change in what is installed since: ",
+      paste(utils::head(refs[!keep], 5L), collapse = ", "),
+      if (sum(!keep) > 5L) ", ..." else "",
+      verbose = verbose, verboseLevel = 1)
+  refs[keep]
+}
+
 pakSerialInstall <- function(pkgs, lib, repos, verbose) {
   if (!length(pkgs)) return(invisible(NULL))
+  ## Pin already-installed refs to their installed version so pak keeps them
+  ## rather than replanning a rebuild. pinInstalledForPak() was only ever
+  ## applied to the FIRST batch, so every later phase handed pak unpinned refs
+  ## and its plans came back full of same-version "updates" of packages the
+  ## previous phase had just installed (#190). Passing `pkgs` as resolvedPkgs
+  ## keeps any ref carrying a `( ... )` version spec unpinned, so a user's
+  ## upgrade or downgrade request is never masked by what happens to be
+  ## installed.
+  pkgs <- pinInstalledForPak(pkgs, libPaths = lib, resolvedPkgs = pkgs)
   opts <- options(repos = repos)
   on.exit(options(opts), add = TRUE)
   failed <- character(0)
@@ -3759,6 +3809,9 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
     capturePak(pakRetryLoop(pkgs, repos, verbose))
   } else {
     # Iterative identify-and-defer.
+    # Cross-phase record of refs that failed against a given installed set, so
+    # no later phase re-attempts one whose situation has not changed (#190).
+    failMemo <- .pakFailMemo()
     passList <- pkgs
     deferred <- character(0)  # culprit refs (named with their full pak ref)
     maxIter  <- 8L
@@ -3833,6 +3886,9 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
         # fine, and a failure on one ref no longer abort the rest.
         pkgsMissingFallback <- passList[match(missingNamesIter, passNames)]
         pkgsMissingFallback <- pkgsMissingFallback[!is.na(pkgsMissingFallback)]
+        pkgsMissingFallback <- .pakDropUnchangedFailures(
+          failMemo, pkgsMissingFallback, instNow, verbose)
+        .pakRecordFailures(failMemo, pkgsMissingFallback, instNow)
         messageVerbose(
           "identify-and-defer: ", length(missingNamesIter),
           " ref(s) still missing after iter ", iter,
@@ -3879,6 +3935,13 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
       # dependent before its dependency and hit a spurious
       # "dependency 'X' is not available for package 'Y'" build-error.
       deferred <- orderRefsByMissingDepEdges(deferred, allCapturedMsgs)
+      instBeforeDeferred <- tryCatch(
+        rownames(installed.packages(lib.loc = libPaths[1], noCache = TRUE)),
+        error = function(e) character(0))
+      deferred <- .pakDropUnchangedFailures(failMemo, deferred,
+                                            instBeforeDeferred, verbose)
+      if (!length(deferred)) break
+      .pakRecordFailures(failMemo, deferred, instBeforeDeferred)
       messageVerbose(
         "identify-and-defer: installing ", length(deferred),
         " deferred culprit(s) one at a time",
@@ -3896,7 +3959,10 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
           rownames(installed.packages(lib.loc = libPaths[1], noCache = TRUE)),
           error = function(e) character(0))
         stillMissing <- deferred[!extractPkgName(deferred) %in% instNow]
+        stillMissing <- .pakDropUnchangedFailures(failMemo, stillMissing,
+                                                  instNow, verbose)
         if (!length(stillMissing)) break
+        .pakRecordFailures(failMemo, stillMissing, instNow)
         messageVerbose(
           "identify-and-defer: retry ", retry, " -- re-attempting ",
           length(stillMissing), " still-missing culprit(s) now that their ",

--- a/tests/testthat/test-08modules_testthat.R
+++ b/tests/testthat/test-08modules_testthat.R
@@ -243,12 +243,19 @@ test_that("test 8", {
                     ## cascades to a load-time failure even though its own code
                     ## is fine.
                     "fireSenseUtils",
-                    ## Same cascade, newer cause: ggplot2 4.x moved to S7, so
-                    ## ggpubr (1.0.0) now pulls S7 + isoband, and its tree also
-                    ## reaches stringi -- all NeedsCompilation. On a machine
-                    ## where any of those will not build, ggpubr cannot install
-                    ## however sound its own code is. Observed on R 4.4.3/gcc 13
-                    ## and R 4.6, with isoband and stringi the failing builds.
+                    ## Same cascade, newer cause. ggpubr (1.0.0) reaches Deriv
+                    ## through rstatix -> car -> doBy, and Deriv 4.3.0 calls
+                    ## R_ClosureFormals(), added to R's C API in 4.5.0, while
+                    ## declaring only `Depends: Rcpp`. On R < 4.5 the metadata
+                    ## therefore says it is installable and the build fails:
+                    ##   derive_simplif.cpp:376: error:
+                    ##     'R_ClosureFormals' was not declared in this scope
+                    ## Nothing can resolve that -- there is no declared
+                    ## requirement to fall back from, so Deriv 4.2.0 in the
+                    ## Archive is never considered -- and ggpubr cannot install
+                    ## however sound its own code is. (On R 4.6 Deriv builds;
+                    ## ggpubr can still fail there if isoband or stringi will
+                    ## not build.)
                     "ggpubr")
     allInstalledPre <- allInstalled
     allInstalled <- setdiff(allInstalled, knownFails)

--- a/tests/testthat/test-15bugfixes_testthat.R
+++ b/tests/testthat/test-15bugfixes_testthat.R
@@ -1412,33 +1412,38 @@ test_that(".pakDropUnchangedFailures re-attempts only when something new is inst
     character(0))
 })
 
-test_that(".updateIsPossiblyNeeded keeps only what could actually change", {
-  ## updatePackages() handed Install() every installed package as `pkg (HEAD)`
-  ## with no version comparison, so pak planned a reinstall of the whole
-  ## library -- 170 same-version "updates" where base::update.packages()
-  ## correctly found 3.
-  ap <- cbind(Version = c(older = "1.0.0", same = "2.0.0", newer = "3.1.0"))
-  rownames(ap) <- c("older", "same", "newer")
+test_that("a `(HEAD)` CRAN ref does not force a reinstall of what is current", {
+  ## Install() must not reinstall a package it already has -- that is the point
+  ## of the package. `(HEAD)` used to force installedVersionOK = FALSE on every
+  ## row carrying it, so updatePackages() (which tags every installed CRAN
+  ## package `pkg (HEAD)`) asked for the whole library back: 170 same-version
+  ## rebuilds where base::update.packages() correctly found 3.
+  ##
+  ## Nothing downstream corrected it under the default Require.usePak = TRUE:
+  ## the HEAD -> dontInstall comparison lives in doDownloads(), on the legacy
+  ## non-pak path only.
+  mk <- function(pkg, instVer, availVer, repoLoc) {
+    data.table::data.table(
+      Package = pkg, Version = instVer, VersionOnRepos = availVer,
+      packageFullName = paste0(pkg, " (HEAD)"), repoLocation = repoLoc,
+      versionSpec = "HEAD", inequality = "")
+  }
 
-  nms   <- c("older", "same", "newer", "notInRepos", "aGitHubPkg")
-  inst  <- c("1.2.0", "2.0.0", "3.0.0", "9.9.9", "0.0.1")
-  isGH  <- c(FALSE, FALSE, FALSE, FALSE, TRUE)
+  dt <- data.table::rbindlist(list(
+    mk("current",  "1.2.0", "1.2.0", "CRAN"),          # installed == newest
+    mk("ahead",    "1.3.0", "1.2.0", "CRAN"),          # installed newer than repo
+    mk("stale",    "1.0.0", "1.2.0", "CRAN"),          # repo has something newer
+    mk("unknown",  "1.0.0", NA_character_, "CRAN"),    # cannot settle -> install
+    mk("fromGH",   "1.0.0", "1.0.0", "GitHub")         # HEAD moves; must resolve
+  ))
 
-  res <- Require:::.updateIsPossiblyNeeded(nms, inst, isGH, ap)
+  out <- Require:::whichToInstall(dt, install = TRUE, verbose = -2)
+  needInstall <- setNames(out$needInstall, out$Package)
 
-  ## installed is ahead of the repo, and identical to the repo -> nothing to do
-  expect_false(res[[1]])
-  expect_false(res[[2]])
-  ## repo has something strictly newer -> needed
-  expect_true(res[[3]])
-  ## not offered by any repo (archived / repo down) -> cannot prove current
-  expect_true(res[[4]])
-  ## GitHub refs always resolve remotely: HEAD moves without a version bump
-  expect_true(res[[5]])
-
-  ## no usable available.packages() -> exactly the previous behaviour
-  expect_true(all(Require:::.updateIsPossiblyNeeded(nms, inst, isGH, NULL)))
-  expect_true(all(Require:::.updateIsPossiblyNeeded(nms, inst, isGH, ap[0, , drop = FALSE])))
-  expect_identical(Require:::.updateIsPossiblyNeeded(character(0), character(0),
-                                                     logical(0), ap), logical(0))
+  expect_identical(unname(needInstall[["current"]]), Require:::.txtDontInstall)
+  expect_identical(unname(needInstall[["ahead"]]),   Require:::.txtDontInstall)
+  expect_identical(unname(needInstall[["stale"]]),   Require:::.txtInstall)
+  expect_identical(unname(needInstall[["unknown"]]), Require:::.txtInstall)
+  ## a GitHub HEAD ref is still always resolved -- unchanged behaviour
+  expect_identical(unname(needInstall[["fromGH"]]),  Require:::.txtInstall)
 })

--- a/tests/testthat/test-15bugfixes_testthat.R
+++ b/tests/testthat/test-15bugfixes_testthat.R
@@ -1434,7 +1434,7 @@ test_that("a `(HEAD)` CRAN ref does not force a reinstall of what is current", {
     mk("ahead",    "1.3.0", "1.2.0", "CRAN"),          # installed newer than repo
     mk("stale",    "1.0.0", "1.2.0", "CRAN"),          # repo has something newer
     mk("unknown",  "1.0.0", NA_character_, "CRAN"),    # cannot settle -> install
-    mk("fromGH",   "1.0.0", "1.0.0", "GitHub")         # HEAD moves; must resolve
+    mk("noSHA",    "1.0.0", "1.0.0", "GitHub")         # no local SHA -> install
   ))
 
   out <- Require:::whichToInstall(dt, install = TRUE, verbose = -2)
@@ -1444,6 +1444,55 @@ test_that("a `(HEAD)` CRAN ref does not force a reinstall of what is current", {
   expect_identical(unname(needInstall[["ahead"]]),   Require:::.txtDontInstall)
   expect_identical(unname(needInstall[["stale"]]),   Require:::.txtInstall)
   expect_identical(unname(needInstall[["unknown"]]), Require:::.txtInstall)
-  ## a GitHub HEAD ref is still always resolved -- unchanged behaviour
-  expect_identical(unname(needInstall[["fromGH"]]),  Require:::.txtInstall)
+  ## a GitHub row with no local SHA cannot be settled -> keep the old answer
+  expect_identical(unname(needInstall[["noSHA"]]),   Require:::.txtInstall)
+})
+
+test_that("a `(HEAD)` GitHub ref is settled by SHA, not reinstalled blindly", {
+  ## HEAD means "the newest available" for both CRAN-alikes and Git; the Git
+  ## half is a SHA comparison. alreadyExistingDESCFile() is the existing
+  ## implementation -- doDownloads() uses it -- but that is the legacy non-pak
+  ## path, so under Require.usePak = TRUE every GitHub HEAD ref reinstalled
+  ## unconditionally. Reuse, not a second implementation.
+  remoteSHA <- strrep("a", 40)
+  lib <- tempfile("headlib"); dir.create(lib)
+  on.exit(unlink(lib, recursive = TRUE), add = TRUE)
+  mkInstalled <- function(pkg, sha) {
+    dir.create(file.path(lib, pkg), recursive = TRUE, showWarnings = FALSE)
+    writeLines(c(paste0("Package: ", pkg), "Version: 1.0.0",
+                 paste0("GithubSHA1: ", sha)),
+               file.path(lib, pkg, "DESCRIPTION"))
+  }
+  mkInstalled("atHead", remoteSHA)
+  mkInstalled("behind", strrep("b", 40))
+
+  mkGH <- function(pkg) data.table::data.table(
+    Package = pkg, Version = "1.0.0", VersionOnRepos = NA_character_,
+    packageFullName = paste0("acct/", pkg, "@main (HEAD)"),
+    repoLocation = "GitHub", versionSpec = "HEAD", inequality = "",
+    Account = "acct", Repo = pkg, Branch = "main")
+  dt <- data.table::rbindlist(list(mkGH("atHead"), mkGH("behind")))
+
+  testthat::with_mocked_bindings(
+    getSHAfromGitHubMemoise = function(...) remoteSHA,
+    {
+      out <- Require:::whichToInstall(dt, install = TRUE, verbose = -2,
+                                      libPaths = lib)
+      needInstall <- setNames(out$needInstall, out$Package)
+      ## local SHA == branch HEAD -> nothing to do
+      expect_identical(unname(needInstall[["atHead"]]), Require:::.txtDontInstall)
+      ## local SHA differs -> install
+      expect_identical(unname(needInstall[["behind"]]), Require:::.txtInstall)
+    },
+    .package = "Require")
+
+  ## an unreachable GitHub must not be read as "up to date"
+  testthat::with_mocked_bindings(
+    getSHAfromGitHubMemoise = function(...) stop("no network"),
+    {
+      out <- Require:::whichToInstall(dt, install = TRUE, verbose = -2,
+                                      libPaths = lib)
+      expect_true(all(out$needInstall == Require:::.txtInstall))
+    },
+    .package = "Require")
 })

--- a/tests/testthat/test-15bugfixes_testthat.R
+++ b/tests/testthat/test-15bugfixes_testthat.R
@@ -1370,3 +1370,75 @@ test_that(".pinSurvivorToMinimumAfterExactReject() handles empty/malformed input
   expect_silent(Require:::.pinSurvivorToMinimumAfterExactReject(
     pkgDT, NULL))
 })
+
+test_that(".pakDropUnchangedFailures re-attempts only when something new is installed", {
+  ## #190: identify-and-defer ran several phases, each deciding independently
+  ## what to attempt, so a ref that cannot build was handed to pak once per
+  ## phase against an identical installed set. Retrying is only useful when a
+  ## dependency has landed since the last attempt.
+  memo <- Require:::.pakFailMemo()
+  refs <- c("any::Deriv", "any::car")
+  inst1 <- c("cli", "rlang")
+
+  ## nothing recorded yet -> everything is attempted
+  expect_identical(
+    Require:::.pakDropUnchangedFailures(memo, refs, inst1, verbose = -2), refs)
+
+  Require:::.pakRecordFailures(memo, refs, inst1)
+
+  ## same installed set -> both dropped
+  expect_identical(
+    Require:::.pakDropUnchangedFailures(memo, refs, inst1, verbose = -2),
+    character(0))
+
+  ## the comparison is set-wise, not order-sensitive
+  expect_identical(
+    Require:::.pakDropUnchangedFailures(memo, refs, rev(inst1), verbose = -2),
+    character(0))
+
+  ## one new package anywhere makes them eligible again
+  expect_identical(
+    Require:::.pakDropUnchangedFailures(memo, refs, c(inst1, "glue"), verbose = -2),
+    refs)
+
+  ## a ref that never failed is never dropped
+  expect_identical(
+    Require:::.pakDropUnchangedFailures(memo, "any::brandNew", inst1, verbose = -2),
+    "any::brandNew")
+
+  ## empty in, empty out
+  expect_identical(
+    Require:::.pakDropUnchangedFailures(memo, character(0), inst1, verbose = -2),
+    character(0))
+})
+
+test_that(".updateIsPossiblyNeeded keeps only what could actually change", {
+  ## updatePackages() handed Install() every installed package as `pkg (HEAD)`
+  ## with no version comparison, so pak planned a reinstall of the whole
+  ## library -- 170 same-version "updates" where base::update.packages()
+  ## correctly found 3.
+  ap <- cbind(Version = c(older = "1.0.0", same = "2.0.0", newer = "3.1.0"))
+  rownames(ap) <- c("older", "same", "newer")
+
+  nms   <- c("older", "same", "newer", "notInRepos", "aGitHubPkg")
+  inst  <- c("1.2.0", "2.0.0", "3.0.0", "9.9.9", "0.0.1")
+  isGH  <- c(FALSE, FALSE, FALSE, FALSE, TRUE)
+
+  res <- Require:::.updateIsPossiblyNeeded(nms, inst, isGH, ap)
+
+  ## installed is ahead of the repo, and identical to the repo -> nothing to do
+  expect_false(res[[1]])
+  expect_false(res[[2]])
+  ## repo has something strictly newer -> needed
+  expect_true(res[[3]])
+  ## not offered by any repo (archived / repo down) -> cannot prove current
+  expect_true(res[[4]])
+  ## GitHub refs always resolve remotely: HEAD moves without a version bump
+  expect_true(res[[5]])
+
+  ## no usable available.packages() -> exactly the previous behaviour
+  expect_true(all(Require:::.updateIsPossiblyNeeded(nms, inst, isGH, NULL)))
+  expect_true(all(Require:::.updateIsPossiblyNeeded(nms, inst, isGH, ap[0, , drop = FALSE])))
+  expect_identical(Require:::.updateIsPossiblyNeeded(character(0), character(0),
+                                                     logical(0), ap), logical(0))
+})


### PR DESCRIPTION
Closes #190.

Two fixes, both about the installer being asked for work that does not need doing.

## 1. `(HEAD)` forced a reinstall of packages already current

`Require::Install()` not reinstalling something you already have is the point of the package. It was doing so for any ref carrying `(HEAD)`.

`whichToInstall()` (`R/Require2.R:1119`):

```r
pkgDT <- checkHEAD(pkgDT)
if (any(pkgDT[[hasHEADtxt]]))
  set(pkgDT, which(pkgDT[[hasHEADtxt]]), "installedVersionOK", FALSE)   # unconditional
```

which becomes `needInstall = "install"`. `checkHEAD()` only ever *sets* that flag — it greps `(HEAD)` out of `packageFullName` and has no path that clears it.

The comparison that would have corrected the decision lives in `doDownloads()`, reachable only from `doInstalls()`, which is the **`else` branch** of `if (getOption("Require.usePak"))`. Under the default `usePak = TRUE` it never runs.

`updatePackages()` builds `pkg (HEAD)` for every row of `installed.packages()`, so this asked for the entire library back. Same machine, same moment:

| | packages requested |
|---|---|
| `base::update.packages(ask = FALSE)` | **3** |
| `Require::updatePackages()` | **170** |

Of the 170, exactly one — `RcppParallel 6.2.0 → 6.2.1` — was a real version change. The rest were `X → X`, rebuilt from source.

**Fix:** a CRAN-form `(HEAD)` ref is settled against `VersionOnRepos`. GitHub rows are untouched — a branch HEAD moves without the DESCRIPTION version changing, so only a SHA comparison settles those. A row with either version unknown keeps the old "install" answer, so nothing is silently skipped.

An earlier revision of this PR filtered inside `updatePackages()` instead. That was the wrong level — it papered over a broken contract that every caller of a `(HEAD)` ref hits — and has been removed.

## 2. identify-and-defer retried an unchanged failure (#190)

`pinInstalledForPak()` was called at exactly one site, on the first batch, so every later phase handed pak unpinned refs and its plans came back full of same-version rebuilds. Now applied at `pakSerialInstall()` entry, with the refs passed as `resolvedPkgs` so a ref carrying a `( … )` version spec stays unpinned and a user's upgrade/downgrade request is never masked.

The no-progress guard covered only the deferred-retry loop, so a ref that cannot build was retried once per phase — iteration loop → serial fallback → deferred serial → retries — five times against an identical installed set. `.pakFailMemo()` records the installed set at each failure and drops a ref whose set is unchanged; any newly installed package makes it eligible again, erring toward one wasted retry over refusing something just unblocked.

## Verification

| | |
|---|---|
| `test-15bugfixes` | FAIL 0 \| WARN 0 \| PASS 117 |
| `test-15bugfixes` + `test-17usePak` (fix 2 only) | FAIL 0 \| WARN 0 \| PASS 291 |
| full suite | running |

New tests cover the `(HEAD)` decision across current / ahead-of-repo / stale / unknown-version / GitHub rows, and the memo's degrade paths and order-insensitivity.

## Risk

Fix 1 changes **core install-decision logic** and affects every `Install()` call, not one function. It should not merge before the full suite and CI are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzuEzwPrFEdAN3yUX18GgD