### PR TITLE
refactor: drop Require:: from the package's own calls

### DIFF
--- a/R/Require2.R
+++ b/R/Require2.R
@@ -4472,7 +4472,7 @@ buildCmdLine <- function(tmpdir, fn, doLine, downAndBuildLocal, outfile, libPath
     notInstalled <- setdiff(.RequireDependenciesNoBase, installed)
     if (length(notInstalled)) {
       # warning is about restart R; not relevant here
-      suppressWarnings(Require::Install(notInstalled, verbose = -2, libPaths = libPaths[1]))
+      suppressWarnings(Install(notInstalled, verbose = -2, libPaths = libPaths[1]))
     }
     ar <- c(paste0(".libPaths('", libPaths[1], "')"), ar)
   }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -604,7 +604,7 @@ SysInfo <-
 
 .cleanup <- function(opts = list()) {
   unlink(file.path(tempdir(), "Require"), recursive = TRUE)
-  unlink(Require::tempdir2(create = FALSE), recursive = TRUE)
+  unlink(tempdir2(create = FALSE), recursive = TRUE)
   cacheClearPackages(
     ask = FALSE,
     Rversion = versionMajorMinor(),

--- a/R/pak.R
+++ b/R/pak.R
@@ -880,10 +880,10 @@ DESCRIPTIONfileFromModule <- function(module, md, deps, hasNamespaceFile, NAMESP
   # if (all(!hasSC))
   #   deps <- c("SpaDES.core", deps)
 
-  d$Imports <- Require::extractPkgName(deps)
-  versionNumb <- Require::extractVersionNumber(deps)
-  needRemotes <- which(!is.na(Require::extractPkgGitHub(deps)))
-  d$Remotes <- Require::trimVersionNumber(deps[needRemotes])
+  d$Imports <- extractPkgName(deps)
+  versionNumb <- extractVersionNumber(deps)
+  needRemotes <- which(!is.na(extractPkgGitHub(deps)))
+  d$Remotes <- trimVersionNumber(deps[needRemotes])
 
   hasVersionNumb <- !is.na(versionNumb)
   inequality <- paste0("(", gsub("(.+)\\((.+)\\)", "\\2", deps[hasVersionNumb]), ")")

--- a/R/pkgDep.R
+++ b/R/pkgDep.R
@@ -832,7 +832,7 @@ defaultCacheAgeForPurge <- 3600
 cachePurge <- function(packages = FALSE,
                        repos = getOption("repos")) {
   if (isTRUE(packages))
-    Require::cacheClearPackages(ask = FALSE)
+    cacheClearPackages(ask = FALSE)
   dealWithCache(TRUE, repos = repos)
 }
 


### PR DESCRIPTION
Self-qualifying a call inside the package that defines it makes the call depend on the object staying **exported**. That is not hypothetical — it caused a CI failure earlier today. An orphaned roxygen block dropped `export(extractPkgGitHub)` from NAMESPACE, and

```r
needRemotes <- which(!is.na(Require::extractPkgGitHub(deps)))
```

became `Missing or unexported object` and failed `R CMD check` on every runner. A bare call would have been unaffected.

## Changed

Seven call sites de-qualified:

| file | functions |
|---|---|
| `R/pak.R` | `extractPkgName`, `extractVersionNumber`, `extractPkgGitHub`, `trimVersionNumber` |
| `R/helpers.R` | `tempdir2` |
| `R/pkgDep.R` | `cacheClearPackages` |
| `R/Require2.R` | `Install` |

## Deliberately kept

Six occurrences keep `Require::` because they are not calls in this session:

- user-facing message text naming the function to run (`"Run Require::Install(...)"`)
- the `do.call(Require:::downloadAndBuildToLocalFile, args)` string, evaluated in a subprocess where Require is not attached
- `body(Require::setLibPaths)`, which introspects the exported object to write it into `.Rprofile`

## Verification

`FAIL 0 | WARN 0 | SKIP 0 | PASS 357` across `test-15bugfixes`, `test-17usePak`, `test-02extract`, `test-03helpers`. `R CMD INSTALL` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzuEzwPrFEdAN3yUX18GgD