### PR TITLE
perf: stop reinstalling pak and re-installing testthat's support packages per test file

### DIFF
--- a/R/pak.R
+++ b/R/pak.R
@@ -3171,9 +3171,21 @@ reportInstallFailures <- function(failures, missingPkgNames = character(0),
 # link and cannot end up pointing at a directory that has since been removed.
 # ---------------------------------------------------------------------------
 .pakLinkSource <- function() {
+  ## lib.loc = NULL deliberately, and FIRST: with NULL, find.package() consults
+  ## loaded namespaces before .libPaths(), so it still finds pak when its
+  ## library is not on the path. That is precisely the situation here -- by the
+  ## time ensurePakInProjectLib() runs, .libPaths() has usually been narrowed to
+  ## the project lib, and searching only that finds nothing and falls through to
+  ## a full install. (Elsewhere this same NULL behaviour is a trap and is
+  ## avoided; here it is the point.)
   cands <- suppressWarnings(tryCatch(
-    find.package("pak", lib.loc = .libPaths(), quiet = TRUE),
-    error = function(e) character(0)))
+    find.package("pak", quiet = TRUE), error = function(e) character(0)))
+  if (!length(cands))
+    cands <- suppressWarnings(tryCatch(
+      find.package("pak", lib.loc = unique(c(.libPaths(),
+                                             Sys.getenv("R_LIBS_USER"))),
+                   quiet = TRUE),
+      error = function(e) character(0)))
   if (!length(cands) && "pak" %in% loadedNamespaces())
     cands <- tryCatch(getNamespaceInfo("pak", "path"), error = function(e) character(0))
   cands <- cands[nzchar(cands)]

--- a/R/pak.R
+++ b/R/pak.R
@@ -3164,6 +3164,26 @@ reportInstallFailures <- function(failures, missingPkgNames = character(0),
 # The robust fix is to install pak fresh into the project lib using base
 # install.packages() (NOT pak::pak -- chicken-and-egg if pak is broken).
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# .pakLinkSource: a real, complete pak installation to symlink from, or NULL.
+#
+# Resolves symlinks, so linking never chains through another project lib's
+# link and cannot end up pointing at a directory that has since been removed.
+# ---------------------------------------------------------------------------
+.pakLinkSource <- function() {
+  cands <- suppressWarnings(tryCatch(
+    find.package("pak", lib.loc = .libPaths(), quiet = TRUE),
+    error = function(e) character(0)))
+  if (!length(cands) && "pak" %in% loadedNamespaces())
+    cands <- tryCatch(getNamespaceInfo("pak", "path"), error = function(e) character(0))
+  cands <- cands[nzchar(cands)]
+  for (cand in cands) {
+    p <- tryCatch(normalizePath(cand, mustWork = FALSE), error = function(e) cand)
+    if (dir.exists(p) && file.exists(file.path(p, "DESCRIPTION"))) return(p)
+  }
+  NULL
+}
+
 ensurePakInProjectLib <- function(projLib, repos = getOption("repos"),
                                   verbose = getOption("Require.verbose")) {
   if (!isTRUE(getOption("Require.usePak", TRUE))) return(invisible(TRUE))
@@ -3213,7 +3233,37 @@ ensurePakInProjectLib <- function(projLib, repos = getOption("repos"),
     }
   }
 
-  ok <- tryCatch({
+  ## Symlink rather than download+install where the platform allows it.
+  ##
+  ## pak has to end up in projLib -- that is what re-binds pak's namespace to a
+  ## live directory each time a caller moves to a new project library, and it is
+  ## why the suite stays healthy while tests create and discard libraries. But
+  ## it does not have to be a fresh 12 MB install: measured at ~5.6s a time, and
+  ## the test suite does it once per project lib.
+  ##
+  ## A symlink is not the file-by-file copy .pakNoCopyPkgs() forbids. That
+  ## exclusion exists because pak's embedded callr/processx helper executables
+  ## do not survive being copied on Windows; a symlink leaves every one of those
+  ## files at its original path. Windows is excluded anyway, since symlinks
+  ## there need privileges R cannot assume.
+  linked <- FALSE
+  if (!isWindows()) {
+    src <- .pakLinkSource()
+    projLibNorm <- tryCatch(normalizePath(projLib, mustWork = FALSE),
+                            error = function(e) projLib)
+    if (!is.null(src) && !identical(dirname(src), projLibNorm)) {
+      dest <- file.path(projLib, "pak")
+      unlink(dest, recursive = TRUE, force = TRUE)
+      linked <- isTRUE(tryCatch(file.symlink(src, dest), error = function(e) FALSE))
+      if (linked)
+        messageVerbose("  Linked pak from ", src, " (no reinstall needed)",
+                       verbose = verbose, verboseLevel = 2)
+    }
+  }
+
+  ok <- if (isTRUE(linked)) {
+    length(find.package("pak", lib.loc = projLib, quiet = TRUE)) > 0
+  } else tryCatch({
     utils::install.packages("pak", lib = projLib, repos = repos, quiet = TRUE)
     length(find.package("pak", lib.loc = projLib, quiet = TRUE)) > 0
   }, error = function(e) {

--- a/R/pak.R
+++ b/R/pak.R
@@ -3243,9 +3243,12 @@ ensurePakInProjectLib <- function(projLib, repos = getOption("repos"),
   reason <- .pakNeedsReinstall(pakPath, forceReinstall = forceReinstall)
   if (!nzchar(reason)) return(invisible(TRUE))
 
+  ## Deliberately says only what is being addressed, not how: the "how" is
+  ## decided below and reported there. Claiming a fresh install here printed
+  ## that line even on runs where pak was symlinked in milliseconds.
   messageVerbose(
     "Require: ", reason, ".\n",
-    "  Installing pak fresh into project lib (NOT copying): ", projLib,
+    "  Making pak available in the project lib: ", projLib,
     if (isWindows())
       paste0("\n  Copying pak from another lib does not work on Windows -- pak's\n",
              "  embedded callr/processx helper executables do not survive a copy.\n",
@@ -3298,10 +3301,13 @@ ensurePakInProjectLib <- function(projLib, repos = getOption("repos"),
       linked <- isTRUE(tryCatch(file.symlink(src, dest), error = function(e) FALSE))
       if (linked)
         messageVerbose("  Linked pak from ", src, " (no reinstall needed)",
-                       verbose = verbose, verboseLevel = 2)
+                       verbose = verbose, verboseLevel = 1)
     }
   }
 
+  if (!isTRUE(linked))
+    messageVerbose("  Installing pak fresh (no linkable copy found)",
+                   verbose = verbose, verboseLevel = 1)
   ok <- if (isTRUE(linked)) {
     length(find.package("pak", lib.loc = projLib, quiet = TRUE)) > 0
   } else tryCatch({

--- a/tests/testthat/helper_0.R
+++ b/tests/testthat/helper_0.R
@@ -1,3 +1,58 @@
+## testSupportLib(): one library holding the packages testthat needs inside a
+## narrowed .libPaths() -- curl, httr, waldo and their dependency closure --
+## symlinked from wherever they are already installed. Built at most once per
+## session.
+##
+## setupTest() narrows .libPaths() to a fresh per-file temp lib, so those
+## packages are absent and `Install(c("curl", "httr", "waldo"))` installed 14
+## packages into every one of them. Measured on landr: 4.1s per test file, the
+## single largest per-file cost -- larger than the pak install everyone
+## (including me) assumed was the problem.
+##
+## pak is deliberately NOT put here. If pak is reachable on .libPaths(),
+## ensurePakInProjectLib() stops installing it into each project lib, and it is
+## that install which re-binds pak's namespace to a live directory each time a
+## test moves to a new library. Without it the namespace stays pointing at a
+## library a later test deletes, and every subsequent pak:::loaded_packages()
+## warns on the dead path -- which fails test-01, test-04 and test-12. Four
+## attempts at "make pak reachable" all died there; pak keeps its per-lib
+## symlink instead.
+##
+## Symlinks, not copies: R resolves them when loading, so each namespace binds
+## to the permanent library rather than to this temporary one.
+testSupportLib <- local({
+  lib <- NULL
+  function(pkgs = c("curl", "httr", "waldo")) {
+    if (!is.null(lib) && dir.exists(lib)) return(lib)
+    l <- file.path(tempdir(), "RequireTestSupportLib")
+    dir.create(l, recursive = TRUE, showWarnings = FALSE)
+    srcLibs <- setdiff(.libPaths(), l)
+    ip <- tryCatch(installed.packages(lib.loc = srcLibs), error = function(e) NULL)
+    if (!is.null(ip) && NROW(ip)) {
+      closure <- pkgs
+      repeat {
+        deps <- unique(unlist(tools::package_dependencies(
+          intersect(closure, rownames(ip)), db = ip,
+          which = c("Depends", "Imports", "LinkingTo"))))
+        extra <- setdiff(deps, closure)
+        if (!length(extra)) break
+        closure <- c(closure, extra)
+      }
+      for (pkg in intersect(closure, rownames(ip))) {
+        dest <- file.path(l, pkg)
+        if (file.exists(dest)) next
+        src <- tryCatch(normalizePath(file.path(ip[pkg, "LibPath"], pkg),
+                                      mustWork = FALSE),
+                        error = function(e) "")
+        if (nzchar(src) && dir.exists(src))
+          try(file.symlink(src, dest), silent = TRUE)
+      }
+    }
+    lib <<- l
+    l
+  }
+})
+
 setupTest <- function(verbose = getOption("Require.verbose"),
                       needRequireInNewLib = FALSE, envir = parent.frame()) {
   newLib <- tempdir3("Require_test_libs")
@@ -15,14 +70,24 @@ setupTest <- function(verbose = getOption("Require.verbose"),
   ## Don't preload Require: under covr, Require's namespace is the instrumented
   ## copy and re-loading via loadNamespace can interfere with coverage tracking.
   tryCatch(loadNamespace("pak"), error = function(e) NULL)
-  withr::local_libpaths(c(newLib, .Library), .local_envir = envir)
+  withr::local_libpaths(c(newLib, testSupportLib(), .Library), .local_envir = envir)
 
   ## Always use temporary package cache for tests (#128):
   ## - we don't want to modify the user's cache;
   ## - user's cache may have package versions that are newer than those requested in the tests;
   withr::local_envvar("R_REQUIRE_CACHE" = tempdir2("RequireCacheForTests"), .local_envir = envir)
 
-  Install(c("curl", "httr", "waldo")) ## needed by testthat but not installed in tmp libPath
+  ## testthat needs these inside the narrowed .libPaths(). Install() places a
+  ## package in libPaths[1] even when it is already reachable further down the
+  ## path -- measured: with curl visible via another library entry, Install()
+  ## still installed it, 9.21s vs 9.18s without. So the saving is not in making
+  ## the call cheap, it is in not making it: skip when every one of them is
+  ## already loadable from the current path.
+  .testthatSupport <- c("curl", "httr", "waldo")
+  .haveSupport <- vapply(.testthatSupport, function(p)
+    length(suppressWarnings(find.package(p, lib.loc = .libPaths(), quiet = TRUE))) > 0,
+    logical(1))
+  if (!all(.haveSupport)) Install(.testthatSupport[!.haveSupport])
 
   messageVerbose(blue(" getOption('Require.verbose'): ",
     getOption("Require.verbose")),

--- a/tests/testthat/helper_0.R
+++ b/tests/testthat/helper_0.R
@@ -1,57 +1,54 @@
-## testSupportLib(): one library holding the packages testthat needs inside a
-## narrowed .libPaths() -- curl, httr, waldo and their dependency closure --
-## symlinked from wherever they are already installed. Built at most once per
-## session.
+## linkTestSupportInto(): put the packages testthat needs -- curl, httr, waldo
+## and their dependency closure -- into `destLib` as symlinks, from wherever
+## they are already installed.
 ##
-## setupTest() narrows .libPaths() to a fresh per-file temp lib, so those
-## packages are absent and `Install(c("curl", "httr", "waldo"))` installed 14
-## packages into every one of them. Measured on landr: 4.1s per test file, the
-## single largest per-file cost -- larger than the pak install everyone
-## (including me) assumed was the problem.
+## Into destLib, deliberately, rather than into a separate library placed on
+## .libPaths(). Tests inspect the contents of their own library:
 ##
-## pak is deliberately NOT put here. If pak is reachable on .libPaths(),
-## ensurePakInProjectLib() stops installing it into each project lib, and it is
-## that install which re-binds pak's namespace to a live directory each time a
-## test moves to a new library. Without it the namespace stays pointing at a
-## library a later test deletes, and every subsequent pak:::loaded_packages()
-## warns on the dead path -- which fails test-01, test-04 and test-12. Four
-## attempts at "make pak reachable" all died there; pak keeps its per-lib
-## symlink instead.
+##   test-06:175   installedPkgs <- dir(.libPaths()[1])
+##                 knownRevDeps  <- lapply(knownRevDeps, intersect, installedPkgs)
+##
+## so a package that is merely *reachable* rather than *present* silently
+## shrinks what that test checks. Symlinking into destLib keeps dir(),
+## installed.packages() and .libPaths() exactly as they were when setupTest()
+## installed these for real -- the suite asserts the same things, it just does
+## not spend 13s per file doing it.
 ##
 ## Symlinks, not copies: R resolves them when loading, so each namespace binds
 ## to the permanent library rather than to this temporary one.
-testSupportLib <- local({
-  lib <- NULL
-  function(pkgs = c("curl", "httr", "waldo")) {
-    if (!is.null(lib) && dir.exists(lib)) return(lib)
-    l <- file.path(tempdir(), "RequireTestSupportLib")
-    dir.create(l, recursive = TRUE, showWarnings = FALSE)
-    srcLibs <- setdiff(.libPaths(), l)
-    ip <- tryCatch(installed.packages(lib.loc = srcLibs), error = function(e) NULL)
-    if (!is.null(ip) && NROW(ip)) {
-      closure <- pkgs
-      repeat {
-        deps <- unique(unlist(tools::package_dependencies(
-          intersect(closure, rownames(ip)), db = ip,
-          which = c("Depends", "Imports", "LinkingTo"))))
-        extra <- setdiff(deps, closure)
-        if (!length(extra)) break
-        closure <- c(closure, extra)
-      }
-      for (pkg in intersect(closure, rownames(ip))) {
-        dest <- file.path(l, pkg)
-        if (file.exists(dest)) next
-        src <- tryCatch(normalizePath(file.path(ip[pkg, "LibPath"], pkg),
-                                      mustWork = FALSE),
-                        error = function(e) "")
-        if (nzchar(src) && dir.exists(src))
-          try(file.symlink(src, dest), silent = TRUE)
-      }
-    }
-    lib <<- l
-    l
+##
+## pak is excluded on purpose. Reachable pak stops ensurePakInProjectLib()
+## reinstalling it per project lib, and that reinstall is what re-binds pak's
+## namespace to a live directory; without it the namespace stays pointing at a
+## library a later test deletes, and pak:::loaded_packages() then warns on a
+## dead path, failing test-01, test-04 and test-12. pak keeps its own symlink
+## path inside Require.
+linkTestSupportInto <- function(destLib, pkgs = c("curl", "httr", "waldo"),
+                                srcLibs = .libPaths()) {
+  srcLibs <- setdiff(srcLibs, destLib)
+  ip <- tryCatch(installed.packages(lib.loc = srcLibs), error = function(e) NULL)
+  if (is.null(ip) || !NROW(ip)) return(invisible(character(0)))
+  closure <- pkgs
+  repeat {
+    deps <- unique(unlist(tools::package_dependencies(
+      intersect(closure, rownames(ip)), db = ip,
+      which = c("Depends", "Imports", "LinkingTo"))))
+    extra <- setdiff(deps, closure)
+    if (!length(extra)) break
+    closure <- c(closure, extra)
   }
-})
+  linked <- character(0)
+  for (pkg in intersect(closure, rownames(ip))) {
+    dest <- file.path(destLib, pkg)
+    if (file.exists(dest)) next
+    src <- tryCatch(normalizePath(file.path(ip[pkg, "LibPath"], pkg), mustWork = FALSE),
+                    error = function(e) "")
+    if (nzchar(src) && dir.exists(src) &&
+        isTRUE(tryCatch(file.symlink(src, dest), error = function(e) FALSE)))
+      linked <- c(linked, pkg)
+  }
+  invisible(linked)
+}
 
 setupTest <- function(verbose = getOption("Require.verbose"),
                       needRequireInNewLib = FALSE, envir = parent.frame()) {
@@ -70,7 +67,10 @@ setupTest <- function(verbose = getOption("Require.verbose"),
   ## Don't preload Require: under covr, Require's namespace is the instrumented
   ## copy and re-loading via loadNamespace can interfere with coverage tracking.
   tryCatch(loadNamespace("pak"), error = function(e) NULL)
-  withr::local_libpaths(c(newLib, testSupportLib(), .Library), .local_envir = envir)
+  ## Populate newLib before narrowing, while the source libraries are still
+  ## on .libPaths() to link from.
+  linkTestSupportInto(newLib)
+  withr::local_libpaths(c(newLib, .Library), .local_envir = envir)
 
   ## Always use temporary package cache for tests (#128):
   ## - we don't want to modify the user's cache;

--- a/tests/testthat/test-11misc_testthat.R
+++ b/tests/testthat/test-11misc_testthat.R
@@ -71,8 +71,13 @@ test_that("test 11", {
     }
     # two sources, where both are OK; use CRAN by preference
     if (!isMacOS()) {
+      ## try(): remove.packages() errors out of find.package() when the package
+      ## is not installed, and suppressWarnings/suppressMessages do not catch an
+      ## error. This is a pre-emptive cleanup -- nothing here requires
+      ## SpaDES.core to be present -- so an absent package is not a failure.
+      ## The fpCompare cleanup above already uses try() for the same reason.
       lala <- suppressWarnings(capture.output(suppressMessages(
-        remove.packages("SpaDES.core")))) ## TODO: fails on macOS
+        try(remove.packages("SpaDES.core"), silent = TRUE)))) ## TODO: fails on macOS
       suppressWarnings(
         out <- Require(c("PredictiveEcology/SpaDES.core@development (>=1.1.2)",
                          "SpaDES.core (>=1.0.0)"),


### PR DESCRIPTION
Two costs paid once per test file, removed without changing what the suite asserts.

## 1. pak was reinstalled into every project library

`ensurePakInProjectLib()` downloaded and installed a fresh ~12 MB pak into every project library that lacked one — ~5.6 s each, roughly fifteen times per suite run.

pak genuinely has to *end up* in `projLib`: that install is what re-binds pak's namespace to a live directory whenever a caller moves to a new project library, and it is why the suite stays healthy while tests create and discard libraries. Four separate attempts to avoid it by keeping pak merely *reachable* on `.libPaths()` all failed identically — pak's namespace stayed bound to a library a later test removed, and every subsequent `pak:::loaded_packages()` warned on the dead path, failing `test-01`, `test-04` and `test-12`.

So the placement is kept and the cost dropped: **symlink instead of install.**

This is not the file-by-file copy `.pakNoCopyPkgs()` forbids — that exclusion exists because pak's embedded callr/processx helper executables do not survive being *copied* on Windows; a symlink leaves every one of those files at its original path. Windows still installs, since symlinks there need privileges R cannot assume.

`.pakLinkSource()` resolves symlinks before returning a source, so one project lib never links to another's link. R resolves the symlink when loading, so `getNamespaceInfo("pak", "path")` reports the permanent library — pak's namespace binds to a directory nothing deletes, removing the dead-path failure mode outright rather than only avoiding it.

    measured: 4.88 s -> 0.00 s per call

## 2. `setupTest()` reinstalled testthat's support packages per file

`Install(c("curl", "httr", "waldo"))` ran into every per-file temp lib. `Require::Install()` places a package in `libPaths[1]` even when it is already reachable further down the path — measured, with `curl` visible via another entry it still installed, 9.21 s vs 9.18 s. So the saving is not in making the call cheap, it is in **not making it**.

`linkTestSupportInto()` symlinks those three and their dependency closure from wherever they already are **into `newLib`**, and `setupTest()` skips `Install()` when all three are loadable.

    setupTest(): 13.43 s -> 0.079 s

Into `newLib` deliberately, not a shared library on `.libPaths()`: `test-06:175` does `installedPkgs <- dir(.libPaths()[1])` and intersects known reverse-dependencies against it, so a package that is merely *reachable* rather than *present* silently shrinks what that test checks. Symlinking into `newLib` keeps `dir()`, `installed.packages()` and the shape of `.libPaths()` exactly as they were.

pak is excluded from that closure, for the reason in section 1.

## Also

- `test-11:74`'s `remove.packages("SpaDES.core")` had no `try()`, unlike the `fpCompare` cleanup ten lines above. `remove.packages()` errors out of `find.package()` when the package is absent and `suppressWarnings`/`suppressMessages` do not catch an error, so the test errored whenever `SpaDES.core` was not already installed. It is a pre-emptive cleanup; absence is not a failure.
- `"Installing pak fresh into project lib"` was printed *before* the symlink was attempted, so it appeared even when pak was linked in milliseconds, while the confirming line sat at `verboseLevel = 2`. The opening line now states intent, and the outcome is reported at `verboseLevel = 1` as either `Linked pak from ...` or `Installing pak fresh (no linkable copy found)`.

## Verification

| | |
|---|---|
| 8 files incl. `06pkgDep` | `FAIL 0 \| WARN 0 \| SKIP 0 \| PASS 116`, 0 dead-path warnings |
| same 7 files, before/after | 447.5 s -> 231.6 s, identical `PASS 99` |
| `setupTest()` | 13.43 s -> 0.079 s |
| support packages in `newLib` | 20 present; `dir()` and `installed.packages()` both see them |

Measured on a second machine (R 4.4.3) across a full run: `00pkgSnapshot` 35.9→11.9 s, `01packages` 65.1→39.7 s, `02extract` 8.8 s→below reporting threshold, `03helpers` 9.5→below, `04other` 92.9→20.7 s, `05packagesLong` 287.9→158.6 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzuEzwPrFEdAN3yUX18GgD