### PR TITLE
test: pin Deriv 4.2.0 on R < 4.5 rather than excusing ggpubr

### DIFF
--- a/tests/testthat/test-08modules_testthat.R
+++ b/tests/testthat/test-08modules_testthat.R
@@ -93,6 +93,23 @@ test_that("test 8", {
     }
     # THE INSTALL
     pkgs <- c(pkgs, "xml2 (>=1.5.2)")
+
+    ## Deriv 4.3.0 calls R_ClosureFormals(), added to R's C API in 4.5.0, while
+    ## declaring only `Depends: Rcpp`. On R < 4.5 the metadata therefore says it
+    ## is installable and the build fails with
+    ##   derive_simplif.cpp:376: 'R_ClosureFormals' was not declared in this scope
+    ## Nothing downstream can resolve that -- there is no declared requirement
+    ## to fall back from -- and ggpubr reaches Deriv via rstatix -> car -> doBy,
+    ## so ggpubr became uninstallable too.
+    ##
+    ## Pin the last version that predates the API use rather than excusing
+    ## ggpubr from the check. Deriv 4.2.0 is pure R (NeedsCompilation: no, no
+    ## src/ at all), so it cannot fail to build on any R version, and CRAN
+    ## serves it from the Archive indefinitely. Only on R < 4.5: on newer R the
+    ## pin would be a pointless downgrade.
+    if (getRversion() < "4.5.0")
+      pkgs <- c("Deriv (==4.2.0)", pkgs)
+
     pkgs <- omitPkgsTemporarily(pkgs)
 
     (
@@ -242,21 +259,7 @@ test_that("test 8", {
                     ## those fail to compile under R 4.5/gcc 13, fireSenseUtils
                     ## cascades to a load-time failure even though its own code
                     ## is fine.
-                    "fireSenseUtils",
-                    ## Same cascade, newer cause. ggpubr (1.0.0) reaches Deriv
-                    ## through rstatix -> car -> doBy, and Deriv 4.3.0 calls
-                    ## R_ClosureFormals(), added to R's C API in 4.5.0, while
-                    ## declaring only `Depends: Rcpp`. On R < 4.5 the metadata
-                    ## therefore says it is installable and the build fails:
-                    ##   derive_simplif.cpp:376: error:
-                    ##     'R_ClosureFormals' was not declared in this scope
-                    ## Nothing can resolve that -- there is no declared
-                    ## requirement to fall back from, so Deriv 4.2.0 in the
-                    ## Archive is never considered -- and ggpubr cannot install
-                    ## however sound its own code is. (On R 4.6 Deriv builds;
-                    ## ggpubr can still fail there if isoband or stringi will
-                    ## not build.)
-                    "ggpubr")
+                    "fireSenseUtils")
     allInstalledPre <- allInstalled
     allInstalled <- setdiff(allInstalled, knownFails)
     cat("\n=== test-08 allInstalled diagnostic ===\n",


### PR DESCRIPTION
`ggpubr` was added to `test-08`'s `knownFails` earlier today because it could not install. That removed it from the check entirely. Pinning the dependency that actually breaks keeps it verified instead.

## Cause

`Deriv 4.3.0` calls `R_ClosureFormals()`, added to R's C API in **4.5.0**, while declaring only `Depends: Rcpp`. On R < 4.5 the metadata therefore claims it is installable, every resolver tries, and the build fails:

```
derive_simplif.cpp:376:28: error: 'R_ClosureFormals' was not declared in this scope
```

Nothing downstream can resolve that — there is no declared requirement to fall back from, so `Deriv 4.2.0` in the Archive is never considered. `ggpubr` reaches `Deriv` via `rstatix → car → doBy` and became uninstallable with it.

## Change

```r
if (getRversion() < "4.5.0")
  pkgs <- c("Deriv (==4.2.0)", pkgs)
```

and `ggpubr` comes out of `knownFails`.

`Deriv 4.2.0` is an unusually safe pin: `NeedsCompilation: no`, **no `src/` directory at all**, `Imports: methods`. It cannot fail to build on any R version, and CRAN serves Archive versions indefinitely.

Guarded to R < 4.5 so newer R does not get a pointless downgrade of a package that builds fine there.

## Verification

`Require::Install("Deriv (==4.2.0)")` resolves from the CRAN Archive and installs 4.2.0.

**Not verified end to end.** The development machine is R 4.6.1, so `getRversion() < "4.5.0"` is `FALSE` and this branch never executes there — `test-08`'s module install cannot exercise it locally. It needs a run on R < 4.5.

## Risk

Pinning `Deriv` also constrains anything else in that module dependency set wanting a newer one. Nothing obvious does (`doBy` accepts any version), and a conflict would surface as a resolution error rather than a silent build failure.

## Upstream

Worth reporting to the `Deriv` maintainer: a correct `Depends: R (>= 4.5.0)` would make every resolver fall back to 4.2.0 automatically, and no downstream package would need to know about this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzuEzwPrFEdAN3yUX18GgD