### PR TITLE
test: do not let the caller's search() path decide whether test-14 finishes

### DIFF
--- a/tests/testthat/test-14coverage2_testthat.R
+++ b/tests/testthat/test-14coverage2_testthat.R
@@ -178,6 +178,21 @@ test_that("pkgDepTopoSort with local packages", {
   testthat::expect_true(is.list(out4))
 
   # useAllInSearch = TRUE, no deps (reads search() path)
+  ##
+  ## useAllInSearch appends *every non-core package in search()* to `packages`
+  ## and resolves dependencies for all of them, so this call's cost is set by
+  ## the caller's attached packages, not by anything the test controls. Under
+  ## Rscript search() is short and it takes ~2s; from an interactive session
+  ## with devtools/testthat attached it resolves that whole set through pak and
+  ## does not return in any useful time. It stalls reliably at this line and
+  ## nowhere else.
+  ##
+  ## Skip rather than let the caller's environment decide whether the suite
+  ## finishes. The branch stays covered wherever the suite normally runs -- CI,
+  ## R CMD check and plain Rscript all have a short search path.
+  skip_if(length(search()) > 12,
+          paste0("useAllInSearch scales with search(); ", length(search()),
+                 " entries attached would resolve them all"))
   out5 <- pkgDepTopoSort("data.table", useAllInSearch = TRUE)
   testthat::expect_true(is.list(out5))
 


### PR DESCRIPTION
`test-14`'s `pkgDepTopoSort` block stalls indefinitely when the suite is run from an interactive session — reliably, and at exactly one line:

```r
out5 <- pkgDepTopoSort("data.table", useAllInSearch = TRUE)
```

## Why

From `?pkgDep`:

> `useAllInSearch` — If `TRUE`, then **all non-core R packages in `search()`** will be appended to `packages`

So the call resolves dependencies for every attached package. Its cost is set by the *caller's* environment, not by anything the test controls.

| context | `search()` | result |
|---|---|---|
| `Rscript` | 9 entries | 0.75 s (R 4.6), 2.34 s (R 4.4.3) |
| interactive + devtools/testthat | ~20 | does not return |

Confirmed two independent ways: a `Location`-reporter run showed the last success at line 178 and no further progress, and running the single call by hand in an interactive R 4.4.3 session stalls on its own, outside any test harness.

## Change

Skip above 12 `search()` entries. The branch stays covered everywhere the suite normally runs — CI, `R CMD check` and plain `Rscript` all have short search paths.

## Not fixed here

`pkgDepTopoSort(useAllInSearch = TRUE)` becoming unusable as the search path grows is a real characteristic of the function, not just a test problem — a user with a loaded session would hit the same wall. That deserves its own issue; this PR only stops it from deciding whether the test suite terminates.

## Verification

`FAIL 0 | WARN 0 | SKIP 0 | PASS 71` under `Rscript`, where the call still executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzuEzwPrFEdAN3yUX18GgD