### PR TITLE
fix(pkgDep): don't resolve non-package entries on the search path

### DIFF
--- a/R/pkgDep.R
+++ b/R/pkgDep.R
@@ -66,10 +66,7 @@ pkgDepTopoSort <- function(packages,
 
   if (isTRUE(useAllInSearch)) {
     if (missing(deps)) {
-      a <- search()
-      a <- setdiff(a, .defaultPackages)
-      a <- gsub("package:", "", a)
-      packages <- unique(c(packages, a))
+      packages <- unique(c(packages, pkgsInSearch()))
     } else {
       messageVerbose(
         "deps is provided; useAllInSearch will be set to FALSE",
@@ -235,6 +232,14 @@ pkgDepTopoSort <- function(packages,
   attr(out, "installSafeGroups") <- dd
 
   return(out)
+}
+
+## Packages attached on the search path. Only attached packages are
+## "package:<name>"; anything else there (devtools-shims, an attach()ed object)
+## is not a package and must not be passed to the resolver, which hangs on it.
+pkgsInSearch <- function() {
+  a <- setdiff(search(), .defaultPackages)
+  gsub("^package:", "", grep("^package:", a, value = TRUE))
 }
 
 .defaultPackages <-

--- a/R/pkgDep.R
+++ b/R/pkgDep.R
@@ -235,7 +235,8 @@ pkgDepTopoSort <- function(packages,
 }
 
 ## Packages attached on the search path. Only attached packages are
-## "package:<name>"; anything else there (devtools-shims, an attach()ed object)
+## "package:<name>"; anything else there -- pkgload's devtools_shims, or any
+## environment from attach(), such as a helper attached in a user's .Rprofile --
 ## is not a package and must not be passed to the resolver, which hangs on it.
 pkgsInSearch <- function() {
   a <- setdiff(search(), .defaultPackages)

--- a/tests/testthat/test-14coverage2_testthat.R
+++ b/tests/testthat/test-14coverage2_testthat.R
@@ -402,3 +402,23 @@ test_that("removeOldFlatCachePkgs removes flat .tar.gz files", {
     testthat::expect_false(file.exists(fakeFile))
   })
 })
+
+test_that("pkgsInSearch skips non-package entries on the search path", {
+  ## devtools attaches "devtools-shims", which is not a package. It used to be
+  ## passed to the resolver, which then hung trying to resolve it -- so this is
+  ## asserted on the selection itself, not via pkgDepTopoSort(), which would
+  ## hang rather than fail if this regressed.
+  attach(list(), name = "devtools-shims", warn.conflicts = FALSE)
+  on.exit(detach("devtools-shims", character.only = TRUE), add = TRUE)
+  attach(list(), name = "aRandomAttachedObject", warn.conflicts = FALSE)
+  on.exit(detach("aRandomAttachedObject", character.only = TRUE), add = TRUE)
+
+  out <- Require:::pkgsInSearch()
+
+  expect_false("devtools-shims" %in% out)
+  expect_false("aRandomAttachedObject" %in% out)
+  ## every remaining entry is a package that is actually attached
+  expect_true(all(paste0("package:", out) %in% search()))
+  ## and a genuinely attached package still comes through
+  expect_true("Require" %in% out || !("package:Require" %in% search()))
+})

--- a/tests/testthat/test-14coverage2_testthat.R
+++ b/tests/testthat/test-14coverage2_testthat.R
@@ -404,10 +404,11 @@ test_that("removeOldFlatCachePkgs removes flat .tar.gz files", {
 })
 
 test_that("pkgsInSearch skips non-package entries on the search path", {
-  ## devtools attaches "devtools-shims", which is not a package. It used to be
-  ## passed to the resolver, which then hung trying to resolve it -- so this is
-  ## asserted on the selection itself, not via pkgDepTopoSort(), which would
-  ## hang rather than fail if this regressed.
+  ## attach() puts non-package environments on the search path: pkgload uses
+  ## devtools_shims, and a .Rprofile may attach its own helpers. These used to
+  ## be passed to the resolver, which then hung trying to resolve them -- so
+  ## this asserts on the selection itself, not via pkgDepTopoSort(), which
+  ## would hang rather than fail if this regressed.
   attach(list(), name = "devtools-shims", warn.conflicts = FALSE)
   on.exit(detach("devtools-shims", character.only = TRUE), add = TRUE)
   attach(list(), name = "aRandomAttachedObject", warn.conflicts = FALSE)


### PR DESCRIPTION
Fixes the test-14 stall.

## Cause

`useAllInSearch = TRUE` built its package list from `search()` by stripping a `package:` prefix and keeping everything else:

```r
a <- search()
a <- setdiff(a, .defaultPackages)
a <- gsub("package:", "", a)
```

But `attach()` puts non-package environments on the search path, and those survived that filter and were handed to pak as if they were packages. pak grinds on such a name indefinitely — measured on landr: `pkgDep("data.table")` 2.08 s, `pkgDep("devtools-shims")` still running when killed at 90 s.

The specific entry that triggered it, `devtools-shims`, comes from an `attach(NULL, name = "devtools-shims")` in a developer's `~/.Rprofile`, gated on `interactive()`. That is why it reproduced only under an interactive `devtools::test()`, on one machine: a plain `Rscript` run of the same file always passed, on every machine and R version.

Note `.defaultPackages` already lists `devtools_shims` (underscore). That entry is correct and unrelated — it is pkgload's real shim environment, from `pkgload::insert_global_shims()`. The two names are similar by coincidence.

## Fix

Keep only `package:*` entries. This covers the class rather than one name: any `attach()`ed environment would have hung the same way.

## Test

The assertion is on the selection (`pkgsInSearch()`), not on `pkgDepTopoSort()` — a test driven through the resolver would *hang* rather than fail if this regressed, which is not something to put in CI.

## Verification

On landr, `R --interactive` (the configuration that hung):

| | before | after |
|---|---|---|
| `devtools::test(filter = "14")` | never completed (killed at 120 s+) | 2.3 s, 75 pass |