### PR TITLE
fix(tests): put Require and its deps in the test library

### DIFF
--- a/tests/testthat/helper_0.R
+++ b/tests/testthat/helper_0.R
@@ -23,6 +23,54 @@
 ## library a later test deletes, and pak:::loaded_packages() then warns on a
 ## dead path, failing test-01, test-04 and test-12. pak keeps its own symlink
 ## path inside Require.
+## requireIntoTestLib(): make Require -- and the deps its own DESCRIPTION
+## declares -- present *in* the test library.
+##
+## Under devtools::test() Require is loaded from source by pkgload, so there is
+## no installed copy anywhere to symlink (a developer machine may have none in
+## its personal library at all). Anything that must *build* against Require --
+## test-08 installs SpaDES.project, which Imports Require -- then fails with
+## "dependency 'Require' is not available".
+##
+## Relying on the personal library via Require.cloneFrom is not a fix: it makes
+## a standAlone test's outcome depend on what happens to be installed there,
+## which is why test-08 passed under one R version and skipped under another on
+## the same machine. So install the package *under test* once per session into
+## a cache library and symlink that in -- the test library then holds the code
+## actually being tested, not whatever the developer happens to have.
+requireSourceLib <- local({
+  cached <- NULL
+  function() {
+    if (!is.null(cached) && dir.exists(file.path(cached, "Require"))) return(cached)
+    src <- tryCatch(find.package("Require"), error = function(e) NULL)
+    ## a source checkout, not an installed package: no Meta/ directory
+    if (is.null(src) || !dir.exists(file.path(src, "R")) || dir.exists(file.path(src, "Meta")))
+      return(NULL)
+    lib <- file.path(tempdir(), "Require_source_lib")
+    dir.create(lib, showWarnings = FALSE, recursive = TRUE)
+    ok <- tryCatch(system2(file.path(R.home("bin"), "R"),
+                           c("CMD", "INSTALL", "--no-docs", "--no-help", "--no-byte-compile",
+                             "-l", shQuote(lib), shQuote(src)),
+                           stdout = FALSE, stderr = FALSE), error = function(e) 1L)
+    if (!identical(as.integer(ok), 0L) || !dir.exists(file.path(lib, "Require"))) return(NULL)
+    cached <<- lib
+    lib
+  }
+})
+
+requireIntoTestLib <- function(destLib) {
+  ## Require's own non-base Imports; pak is excluded on purpose, as above
+  linkTestSupportInto(destLib, pkgs = c("callr", "data.table", "processx", "sys"))
+  srcLib <- requireSourceLib()
+  if (!is.null(srcLib)) {
+    linkTestSupportInto(destLib, pkgs = "Require", srcLibs = srcLib)
+  } else {
+    ## Require is installed for real (e.g. under R CMD check): link it from there
+    linkTestSupportInto(destLib, pkgs = "Require")
+  }
+  invisible(dir.exists(file.path(destLib, "Require")))
+}
+
 linkTestSupportInto <- function(destLib, pkgs = c("curl", "httr", "waldo"),
                                 srcLibs = .libPaths()) {
   srcLibs <- setdiff(srcLibs, destLib)
@@ -54,7 +102,7 @@ setupTest <- function(verbose = getOption("Require.verbose"),
                       needRequireInNewLib = FALSE, envir = parent.frame()) {
   newLib <- tempdir3("Require_test_libs")
   if (needRequireInNewLib) {
-    linkOrCopyPackageFiles("Require", fromLib = .libPaths()[1], newLib)
+    requireIntoTestLib(newLib)
   }
   ## Force-load pak BEFORE narrowing .libPaths(): once a namespace is loaded,
   ## R remembers where it came from even if the lib is no longer on .libPaths().

--- a/tests/testthat/test-08modules_testthat.R
+++ b/tests/testthat/test-08modules_testthat.R
@@ -1,7 +1,7 @@
 test_that("test 8", {
 
   # skip_if(getOption("Require.usePak"), message = "Not an option on usePak = TRUE")
-  setupInitial <- setupTest()
+  setupInitial <- setupTest(needRequireInNewLib = TRUE)
 
   notOnCranOrCI <- getOption("Require.notOnCranOrCI")
   notOnCranOrCIInteractive <- getOption("Require.notOnCranOrCIInteractive")


### PR DESCRIPTION
test-08 was skipping with `SpaDES.project not installable in this environment`.

## Cause

`SpaDES.project` Imports `Require`, so building it needs Require **in the test library**. `setupTest(needRequireInNewLib = TRUE)` was meant to arrange that, but did:

```r
linkOrCopyPackageFiles("Require", fromLib = .libPaths()[1], newLib)
```

Under `devtools::test()` Require is loaded from source by pkgload, so there is no installed copy to link — and on a developer machine there may be none in the personal library either. The link silently did nothing, and the build failed with `dependency 'Require' is not available`. (`magick` was a red herring: it installs fine; it only appears in the error from the first pak transaction, which builds SpaDES.project before its deps land.)

Where it *did* pass, it passed for the wrong reason: `setup.R` sets `Require.cloneFrom = Sys.getenv("R_LIBS_USER")`, and `cloneFrom` copies packages out of the personal library into the destination. So a `standAlone = TRUE` test's outcome depended on what happened to be installed personally — the same machine passed under R 4.6 (Require present) and skipped under R 4.4 (absent).

## Fix

`requireIntoTestLib()` links Require's own non-base Imports (callr, data.table, processx, sys — pak excluded as before), and installs the package *under test* once per session into a cache library, symlinking that in. The test library then holds the code actually being tested rather than whatever the developer has installed.

## Verification

landr, R 4.4.3, with no Require in the personal 4.4 library:

| | before | after |
|---|---|---|
| test-08 | `SKIP 1` — not installable | no skip; proceeds past the SpaDES.project install |

test-08 still fails later, in the ~100-package module install (archived `pryr`, and `quickPlot`/`reproducible` self-conflicts). That is a separate problem, not addressed here.