### PR TITLE
fix(pak): keep pakErrorHandling's package index aligned

### DIFF
--- a/R/pak.R
+++ b/R/pak.R
@@ -340,9 +340,19 @@ pakErrorHandling <- function(err, pkg, packages, verbose = getOption("Require.ve
       versEsc         <- regexEscape(as.character(unlist(vers)))
       patVec <- paste0("^", pkgNoVersionEsc, ".*", versEsc, "|/",
                               pkgNoVersionEsc, ".*", versEsc)
-      whRm <- unlist(unname(lapply(patVec, function(p) {
+      hits <- lapply(patVec, function(p) {
         tryCatch(grep(p, pkg), error = function(e) integer(0))
-      })))
+      })
+      ## whRm: the flattened set of every hit, for the branches that remove a
+      ## set of refs. whRmEach: one index per entry of pkgNoVersion (NA when
+      ## pak named a package that is not in `pkg`, e.g. a transitive dep), for
+      ## the positional `[j]` lookups below. Flattening alone drops the zero-hit
+      ## patterns and shifts every later index, so `whRm[j]` ran off the end
+      ## and put NA into packages[whRm] -- crashing the parser and with it the
+      ## whole retry path.
+      whRm <- unlist(hits)
+      whRmEach <- vapply(hits, function(h) if (length(h)) h[1] else NA_integer_,
+                         integer(1))
 
       if (grp[i] == .txtMissingValueWhereTFNeeded) {
         packages <- pakGetArchive(pkgNoVersion, packages = packages, whRm = whRm, verbose = verbose)
@@ -355,24 +365,26 @@ pakErrorHandling <- function(err, pkg, packages, verbose = getOption("Require.ve
       if (grp[i] == .txtCntInstllDep) {
         whRmAll <- integer()
         for (j in seq_along(pkgNoVersion)) {
+          if (is.na(whRmEach[j])) next # not one of our refs (transitive dep)
           if (isGH(pkgNoVersion[j])) { # "PredictiveEcology/fpCompare (>=2.0.0)"
-            if (is.na(pkg[whRm[j]]) || !length(whRm[j])) next
-            isOK <- pakCheckGHversionOK(pkg[whRm[j]], verbose = verbose)
+            isOK <- pakCheckGHversionOK(pkg[whRmEach[j]], verbose = verbose)
             # pkgDT <- toPkgDTFull(pkg)
             # dl <- pak::pkg_download(trimVersionNumber(pkg), dest_dir = tempdir2())
             # vers <- extractVersionNumber(filenames = basename(dl$fulltarget))
             # isOK <- compareVersion2(vers, versionSpec = pkgDT$versionSpec, inequality = pkgDT$inequality)
             if (isOK %in% FALSE)
-              whRmAll <- c(whRmAll, whRm[j])
+              whRmAll <- c(whRmAll, whRmEach[j])
               # packages <- packages[-whRm[j]]
             next
           }
-          packages2 <- pakGetArchive(pkgNoVersion[j], packages = packages, whRm = whRm[j], verbose = verbose)
+          packages2 <- pakGetArchive(pkgNoVersion[j], packages = packages, whRm = whRmEach[j], verbose = verbose)
           if (!identical(length(packages2), length(packages)))
-            whRmAll <- c(whRmAll, whRm[j])
+            whRmAll <- c(whRmAll, whRmEach[j])
 
         }
-        packages <- packages[-whRmAll]
+        ## x[-integer(0)] is empty, not x: only subset when there is something to drop
+        if (length(whRmAll))
+          packages <- packages[-whRmAll]
         break
       }
 


### PR DESCRIPTION
Root cause of test-08 never rescuing archived packages (e.g. `pryr`, buildable on R 4.4.3 yet always "could not be installed").

## Cause

`pakErrorHandling()` built `whRm` by flattening every grep hit across all patterns. Any package pak named that is not one of ours — a transitive dep — has zero hits, contributes nothing, and shifts every later index. The loop then reads `whRm[j]` positionally, runs off the end, and `pakGetArchive()` crashes:

```
if (hisHasVersion && any(pkgNoVer != packages[whRm]))   # packages[NA] -> NA
Error: missing value where TRUE/FALSE needed
```

`pakInstallFiltered()` catches that crash, prints `--- pak raw error (full) ---`, and the retry path is skipped — so the archive swap for `pryr` never runs. Reproduced deterministically by feeding the captured 112-ref pak error to the parser; `Install("pryr")` alone works because a short error has no transitive names.

## Fix

Keep one index per package (`whRmEach`) for the positional lookups; the flattened set (`whRm`) stays for the branches that remove sets of refs. This replaces the GitHub branch's local NA guard with one shared check, rather than adding another. Also guards `packages[-integer(0)]` (which empties the vector) — reachable once nothing crashes.

## Verification

- Captured 112-ref error: crashed before → `112 in, 112 out` after.
- `test-16installFailureMetadata`: 86 pass, 0 fail.
- End-to-end on landr R 4.4.3 (test-08) in progress.