### PR TITLE
test(08): pryr cannot build on R >= 4.5; list it as a known failure there

### DIFF
--- a/tests/testthat/test-08modules_testthat.R
+++ b/tests/testthat/test-08modules_testthat.R
@@ -260,6 +260,11 @@ test_that("test 8", {
                     ## cascades to a load-time failure even though its own code
                     ## is fine.
                     "fireSenseUtils")
+    ## pryr 0.1.6 -- its last release, archived -- uses C entry points R removed
+    ## from the API in 4.5.0 (NAMED, FRAME, CLOENV, PRVALUE, ...), and its GitHub
+    ## HEAD is the same code, so on R >= 4.5 there is no buildable pryr anywhere.
+    if (getRversion() >= "4.5.0")
+      knownFails <- c(knownFails, "pryr")
     allInstalledPre <- allInstalled
     allInstalled <- setdiff(allInstalled, knownFails)
     cat("\n=== test-08 allInstalled diagnostic ===\n",


### PR DESCRIPTION
With #199 (Require in the test lib) and #200 (parser alignment), test-08 on R 4.6.1 no longer skips and the recovery chain runs to the end: `any::pryr` unresolvable → archive fallback → `url::…/Archive/pryr/pryr_0.1.6.tar.gz` → build. The build fails at the compiler: pryr 0.1.6's `inspect.cpp` uses `NAMED`, `FRAME`, `CLOENV`, `PRVALUE`, … (18 errors), all removed from R's C API in 4.5.0. Its GitHub HEAD (0.1.6.9000, last commit 2023-12) is the same code, so on R ≥ 4.5 there is no buildable pryr from any source. The same code compiles cleanly against R 4.4.3 headers.

That leaves `post-knownFails (n=1): pryr` and the `:272` assertion failing on 4.6.1 only. Gate it the way `Deriv` already is.

landr R 4.6.1 before: `FAIL 1 | PASS 5` (pryr). After this: expected clean; 4.4.3 unaffected.