### PR TITLE
perf(pak): level only the batches pak cannot order itself

### DIFF
--- a/R/pak.R
+++ b/R/pak.R
@@ -3826,7 +3826,9 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
   # GitHub/url refs go to pak with dependencies = FALSE (so their pins are not
   # re-resolved), under which pak does not order builds: install them one
   # dependency level at a time. upgrade = TRUE so a branch ref fetches HEAD.
+  ghDone <- FALSE  # reset by each pakRetryLoop call; set once its GitHub levels succeed
   pakGhByLevel <- function(refs) {
+    if (isTRUE(ghDone)) return(NULL)  # already installed earlier in this pakRetryLoop call
     for (lvl in pakInstallLevels(refs, pakRefToBareName(refs))) {
       e <- try(pakCall(
         pak::pak(lvl, lib = libPaths[1], ask = FALSE,
@@ -3834,10 +3836,12 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
         verbose), silent = TRUE)
       if (is(e, "try-error")) return(e)
     }
+    ghDone <<- TRUE
     e
   }
 
   pakRetryLoop <- function(packages, repos, verbose) {
+    ghDone <<- FALSE
     for (i in seq_len(15)) {
       pkgsIn <- packages
       # Snapshot the captured-messages buffer so we can slice out exactly the
@@ -4122,7 +4126,16 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
         # Restarting the subprocess gives the next iteration clean state.
         if (iter > 1L) pakResetSubprocess()
         iterMsgsStart <- length(allCapturedMsgs) + 1L
-        capturePak(pakRetryLoop(passList, repos, verbose))
+        if (iter == 1L) {
+          capturePak(pakRetryLoop(passList, repos, verbose))
+        } else {
+          ## A batch that already failed once restarts one dependency level at
+          ## a time, so the next culprit aborts only its level rather than the
+          ## whole batch again. The first attempt stays a single call: on an
+          ## install that simply succeeds, levels are only extra pak calls.
+          for (lvl in pakInstallLevels(passList, pakRefToBareName(passList)))
+            capturePak(pakRetryLoop(lvl, repos, verbose))
+        }
         capturedMsgs <- allCapturedMsgs[iterMsgsStart:length(allCapturedMsgs)]
 
         ## Terminate early if pak reports missing system packages. Retrying

--- a/R/pak.R
+++ b/R/pak.R
@@ -3823,6 +3823,20 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
   pinned   <- isTRUE(get0("pakPinnedInstall", envir = pakEnv(), inherits = FALSE))
   cranDeps <- if (pinned) FALSE else NA   # last raw pak error string; used by silentlyFailed warning below
 
+  # GitHub/url refs go to pak with dependencies = FALSE (so their pins are not
+  # re-resolved), under which pak does not order builds: install them one
+  # dependency level at a time. upgrade = TRUE so a branch ref fetches HEAD.
+  pakGhByLevel <- function(refs) {
+    for (lvl in pakInstallLevels(refs, pakRefToBareName(refs))) {
+      e <- try(pakCall(
+        pak::pak(lvl, lib = libPaths[1], ask = FALSE,
+                 dependencies = FALSE, upgrade = TRUE),
+        verbose), silent = TRUE)
+      if (is(e, "try-error")) return(e)
+    }
+    e
+  }
+
   pakRetryLoop <- function(packages, repos, verbose) {
     for (i in seq_len(15)) {
       pkgsIn <- packages
@@ -3863,10 +3877,7 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
       cranUp <- isTRUE(forceUpgrade)
       err <- if (any(ghOrUrl) && any(!ghOrUrl)) {
         # Two separate calls when both types are present
-        e1 <- try(pakCall(
-          pak::pak(packages[ghOrUrl],  lib = libPaths[1], ask = FALSE,
-                   dependencies = FALSE, upgrade = TRUE),
-          verbose), silent = TRUE)
+        e1 <- pakGhByLevel(packages[ghOrUrl])
         e2 <- try(pakCall(
           pak::pak(packages[!ghOrUrl], lib = libPaths[1], ask = FALSE,
                    dependencies = cranDeps, upgrade = cranUp),
@@ -3875,12 +3886,14 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
         # fails return that one; if neither fails return non-try-error.
         if (is(e1, "try-error")) e1 else if (is(e2, "try-error")) e2 else e2
       } else {
-        up <- any(ghOrUrl) || cranUp  # TRUE -> upgrade=TRUE
-        deps <- if (any(ghOrUrl)) FALSE else cranDeps  # GH-only: FALSE; CRAN-only: NA (FALSE when pinned)
-        try(pakCall(
-          pak::pak(packages, lib = libPaths[1], ask = FALSE,
-                   dependencies = deps, upgrade = up),
-          verbose), silent = TRUE)
+        if (any(ghOrUrl)) {
+          pakGhByLevel(packages)
+        } else {
+          try(pakCall(
+            pak::pak(packages, lib = libPaths[1], ask = FALSE,
+                     dependencies = cranDeps, upgrade = cranUp),
+            verbose), silent = TRUE)
+        }
       }
       options(opts)
       options(opts)
@@ -4080,12 +4093,16 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
   # because installed.packages() returns the bare name ("qs").
   pkgNamesAll <- pakRefToBareName(pkgs)
   failMemo <- .pakFailMemo()
-  # One pass per dependency level, so each package's hard deps are installed
-  # before it builds. The graph is this install's: do not let it leak into a
-  # later one that resolved differently, or not at all.
+  # Levels only where pak cannot order builds itself: a pinned install runs
+  # every batch with dependencies = FALSE, so the whole set goes one level at a
+  # time; otherwise the CRAN batch (dependencies = NA, ordered by pak) is one
+  # call and only the GitHub/url batch is levelled, inside pakRetryLoop. Each
+  # pak call costs a few seconds of subprocess and metadata work, so levelling
+  # an ordinary CRAN batch was pure overhead. The graph is this install's: do
+  # not let it leak into a later one that resolved differently, or not at all.
   on.exit(if (exists("pakDepGraph", envir = pakEnv(), inherits = FALSE))
             rm("pakDepGraph", envir = pakEnv()), add = TRUE)
-  levels <- pakInstallLevels(pkgs, pkgNamesAll)
+  levels <- if (pinned) pakInstallLevels(pkgs, pkgNamesAll) else list(pkgs)
   installLevel <- function(pkgs) {
     if (identical(strategy, "original")) {
       capturePak(pakRetryLoop(pkgs, repos, verbose))

--- a/tests/testthat/test-11misc_testthat.R
+++ b/tests/testthat/test-11misc_testthat.R
@@ -31,7 +31,12 @@ test_that("test 11", {
   if (notOnCranOrCIInteractive) {
     # Use a mixture of different types of "off CRAN"
     if (!isMacOS()) {
-      pkgs <- c("knn", "ggplot2 (==3.4.3)", "silly1", "SpaDES.core")
+      ## an archived exact pin, but not older than 4.0.0: quickPlot 1.0.4 imports
+      ## ggplot2::is_ggplot() (new in 4.0.0) without declaring the minimum, so
+      ## an older ggplot2 leaves quickPlot unloadable and SpaDES.core's build
+      ## then fails at lazy-load. Nothing in Require can see an undeclared
+      ## minimum; the fix belongs in quickPlot's DESCRIPTION.
+      pkgs <- c("knn", "ggplot2 (==4.0.0)", "silly1", "SpaDES.core")
       pkgsClean <- extractPkgName(pkgs)
       lala <- try(suppressWarnings(capture.output(suppressMessages(remove.packages(pkgsClean)))), silent = TRUE)
 

--- a/tests/testthat/test-11misc_testthat.R
+++ b/tests/testthat/test-11misc_testthat.R
@@ -32,8 +32,8 @@ test_that("test 11", {
     # Use a mixture of different types of "off CRAN"
     if (!isMacOS()) {
       ## an archived exact pin, but not older than 4.0.0: quickPlot 1.0.4 imports
-      ## ggplot2::is_ggplot() (new in 4.0.0) without declaring the minimum, so
-      ## an older ggplot2 leaves quickPlot unloadable and SpaDES.core's build
+      ## ggplot2::is_ggplot() (absent in 3.4.3, present from 3.5) without declaring
+      ## the minimum, so an older ggplot2 leaves quickPlot unloadable and SpaDES.core's build
       ## then fails at lazy-load. Nothing in Require can see an undeclared
       ## minimum; the fix belongs in quickPlot's DESCRIPTION.
       pkgs <- c("knn", "ggplot2 (==4.0.0)", "silly1", "SpaDES.core")

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1498,8 +1498,10 @@ test_that("pakRetryLoop GitHub batch still uses upgrade=TRUE", {
 test_that("pakRetryLoop single-call branch routes GitHub refs by level and CRAN by cranUp", {
   src <- deparse(body(Require:::pakInstallFiltered))
   oneLine <- paste(src, collapse = "\n")
+  ## covr instruments the body (a counter call lands between `{` and the
+  ## routed call), so allow anything short between the condition and the call.
   testthat::expect_true(
-    grepl("if \\(any\\(ghOrUrl\\)\\)\\s*\\{?\\s*pakGhByLevel\\(packages\\)", oneLine),
+    grepl("if \\(any\\(ghOrUrl\\)\\)[\\s\\S]{0,300}?pakGhByLevel\\(packages\\)", oneLine, perl = TRUE),
     info = "a batch with GitHub/url refs must go through pakGhByLevel()")
   cranCall <- regmatches(oneLine, regexpr(
     "pak::pak\\(packages, [^)]*dependencies = cranDeps[^)]*\\)", oneLine))

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1498,10 +1498,10 @@ test_that("pakRetryLoop GitHub batch still uses upgrade=TRUE", {
 test_that("pakRetryLoop single-call branch routes GitHub refs by level and CRAN by cranUp", {
   src <- deparse(body(Require:::pakInstallFiltered))
   oneLine <- paste(src, collapse = "\n")
-  ## covr instruments the body (a counter call lands between `{` and the
-  ## routed call), so allow anything short between the condition and the call.
+  ## Assert on the calls, not their layout: covr rewrites the body around
+  ## them, so adjacency to the `if (any(ghOrUrl))` test cannot be relied on.
   testthat::expect_true(
-    grepl("if \\(any\\(ghOrUrl\\)\\)[\\s\\S]{0,300}?pakGhByLevel\\(packages\\)", oneLine, perl = TRUE),
+    grepl("pakGhByLevel\\(packages\\)", oneLine),
     info = "a batch with GitHub/url refs must go through pakGhByLevel()")
   cranCall <- regmatches(oneLine, regexpr(
     "pak::pak\\(packages, [^)]*dependencies = cranDeps[^)]*\\)", oneLine))

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -1478,30 +1478,33 @@ test_that("pakRetryLoop GitHub batch still uses upgrade=TRUE", {
   src <- deparse(body(Require:::pakInstallFiltered))
   oneLine <- paste(src, collapse = "\n")
 
-  ## In the two-call branch (mixed batch), the GitHub call must hard-code
-  ## upgrade=TRUE to force fetching the latest commit from the branch.
-  ## Find pak::pak(packages[ghOrUrl], ...) and confirm upgrade = TRUE in
-  ## the same arg list (allowing whitespace + line breaks).
+  ## The GitHub/url batch is installed one dependency level at a time by
+  ## pakGhByLevel(); its pak::pak(lvl, ...) call must hard-code upgrade=TRUE
+  ## to force fetching the latest commit from the branch. Confirm upgrade =
+  ## TRUE in that arg list (allowing whitespace + line breaks).
   ghCall <- regmatches(oneLine, regexpr(
-    "pak::pak\\(packages\\[ghOrUrl\\][^)]*\\)", oneLine))
+    "pak::pak\\(lvl,[^)]*\\)", oneLine))
   testthat::expect_true(length(ghCall) > 0L,
-    info = "must find the pak::pak(packages[ghOrUrl], ...) call")
+    info = "must find pakGhByLevel's pak::pak(lvl, ...) call")
   testthat::expect_true(
     grepl("upgrade\\s*=\\s*TRUE", ghCall),
     info = "GitHub-batch pak call must keep upgrade=TRUE so latest commits are fetched"
   )
 })
 
-# (b) -- single-call branch upgrade flag is `any(ghOrUrl) || cranUp`,
-#         so a CRAN-only batch tracks cranUp (=forceUpgrade) and a GH-only
-#         batch always upgrades. No leaking of forceUpgrade through any
-#         other path.
-test_that("pakRetryLoop single-call branch combines ghOrUrl with cranUp (not forceUpgrade directly)", {
+# (b) -- single-call branch: a batch with any GitHub/url ref goes through
+#         pakGhByLevel() (upgrade=TRUE), and a CRAN-only batch tracks cranUp
+#         (=forceUpgrade). No leaking of forceUpgrade through any other path.
+test_that("pakRetryLoop single-call branch routes GitHub refs by level and CRAN by cranUp", {
   src <- deparse(body(Require:::pakInstallFiltered))
   oneLine <- paste(src, collapse = "\n")
   testthat::expect_true(
-    grepl("up\\s*<-\\s*any\\(ghOrUrl\\)\\s*\\|\\|\\s*cranUp", oneLine),
-    info = "single-call branch must combine ghOrUrl with cranUp")
+    grepl("if \\(any\\(ghOrUrl\\)\\)\\s*\\{?\\s*pakGhByLevel\\(packages\\)", oneLine),
+    info = "a batch with GitHub/url refs must go through pakGhByLevel()")
+  cranCall <- regmatches(oneLine, regexpr(
+    "pak::pak\\(packages, [^)]*dependencies = cranDeps[^)]*\\)", oneLine))
+  testthat::expect_true(length(cranCall) > 0L && grepl("upgrade\\s*=\\s*cranUp", cranCall),
+    info = "the CRAN-only call must use upgrade = cranUp")
 })
 
 # (c) -- pakDepsToPkgDT must pin installed user packages even under

--- a/tests/testthat/test-19smallSnapshot_testthat.R
+++ b/tests/testthat/test-19smallSnapshot_testthat.R
@@ -52,7 +52,9 @@ test_that("small snapshot install pins each package to the requested version", {
                    returnDetails = TRUE)
   )
 
-  ip <- data.table::as.data.table(installed.packages(lib.loc = testlib, noCache = TRUE))
+  ## Require installs into .libPaths()[1], which setLibPaths() may have made an
+  ## R-version subfolder of testlib (it appends the version when interactive()).
+  ip <- data.table::as.data.table(installed.packages(lib.loc = .libPaths()[1], noCache = TRUE))
 
   ## Every snapshot package must be installed in the test lib
   missing <- setdiff(pkgs$Package, ip$Package)

--- a/tests/testthat/test-21snapshotInstallPackages_testthat.R
+++ b/tests/testthat/test-21snapshotInstallPackages_testthat.R
@@ -239,7 +239,7 @@ test_that("a small snapshot installs through the install.packages chain", {
   )
 
   ip <- data.table::as.data.table(
-    installed.packages(lib.loc = testlib, noCache = TRUE))
+    installed.packages(lib.loc = .libPaths()[1], noCache = TRUE))  # the lib Require used: setLibPaths() appends the R version when interactive()
 
   ## the CRAN pins must land at exactly the requested version
   cranPins <- pkgs[is.na(GithubRepo)]


### PR DESCRIPTION
#202 applied one pak call per dependency level to every install. pak already orders a CRAN batch it resolves with `dependencies = NA`, so on an install that simply succeeds the extra calls were pure overhead (+10 s on test-00) — but on a big install levels paid for themselves, because one build failure aborts a whole pak batch and identify-and-defer restarts it per culprit.

So: **one call first, levels on retry.** A CRAN batch is tried as a single call; a pass that already failed restarts one dependency level at a time, so the next culprit aborts only its level. Pinned installs and the GitHub/url batch (`pakGhByLevel()`) still start levelled, because `dependencies = FALSE` gives no ordering, and the GitHub levels are remembered within a `pakRetryLoop` call so its internal retries don't redo them.

## Measurements

Small installs — mega, R 4.6.1, each file in its own R session:

| | before #202 | #202 | this PR |
|---|---|---|---|
| test-00pkgSnapshot | 50.1 s | 65.8 s | **55.4 s** |
| test-01packages | 79.9 s | 95.9 s | **84.6 s** |

The remaining ~5 s is a one-time-per-session metadata fetch for exact pins (available.packages 3.1 s + CRAN archive.rds 1.5 s cold, ~0 warm), paid once in a full `devtools::test()`.

Big install — landr, R 4.6.1, test-08 (100 packages, many GitHub chains):

| | restarts | pak calls | duration | result |
|---|---|---|---|---|
| before #202 | 7 | — | 1193 s | FAIL 1 (pryr) |
| #202 (levels everywhere) | 1 | 25 | 808 s | FAIL 1 (pryr) |
| levels only for GitHub | 10 | 437 | 1085 s | pass |
| **this PR** | 6 | 102 | **684 s** | **pass** |

test-14 88, test-16 86, test-17 184, test-19 9 pass locally.

## Also in this PR: three tests that only failed interactively

- **test-19, test-21**: `setLibPaths()` appends the R version to the library path when `interactive()` (it skips it under R CMD check's tmp libpath), so under an interactive `devtools::test()` Require installed into `testlib/4.6` while the tests checked `testlib`. They now read `.libPaths()[1]`, as test-09 does.
- **test-11:95**: its interactive-only branch pinned `ggplot2 (==3.4.3)`; quickPlot 1.0.4 imports `ggplot2::is_ggplot()` (absent in 3.4.3) without declaring a minimum, so quickPlot could not load and SpaDES.core's build failed at lazy-load. Pin moved to `4.0.0`. The real fix is a `ggplot2 (>= 3.5)` minimum in quickPlot's DESCRIPTION — Require cannot see an undeclared one.