### PR TITLE
fix(tests): guard skip_if_offline2 when curl is unavailable

### DIFF
--- a/tests/testthat/helper_0.R
+++ b/tests/testthat/helper_0.R
@@ -151,6 +151,14 @@ setupTest <- function(verbose = getOption("Require.verbose"),
 skip_if_offline2 <- function() {
   # default with testthat::skip_if_offline is apple.com
   #   which was returning true when wifi connection exists, but no internet e.g., on a plane
+  #
+  # testthat::skip_if_offline() itself needs curl. curl is a Suggests, so it is
+  # absent from the restricted library that _R_CHECK_DEPENDS_ONLY_=true builds
+  # for the no-suggests check leg -- there the skip helper ERRORS rather than
+  # skipping, and takes the whole leg down with it. Guard first.
+  if (!requireNamespace("curl", quietly = TRUE)) {
+    skip("curl not available (no-suggests check)")
+  }
   skip_if_offline("github.com")
 }
   omitPkgsTemporarily <- function(pkgs) {


### PR DESCRIPTION
Fixes the one failing leg on PredictiveEcology/Require#206 — `ubuntu-latest (release, nosuggests)`, which reports:

```
Error in `skip_if_offline("github.com")`: The package "curl" is required.
```

## Why

`testthat::skip_if_offline()` needs `curl`. `curl` is in `Suggests`, so it is **not** in the restricted library that `_R_CHECK_DEPENDS_ONLY_=true` builds for the no-suggests leg. There the helper meant to *skip* a test instead **errors**, taking the whole leg down.

All ten test files call `skip_if_offline2()`, so the guard goes in that single helper rather than at each call site.

## Note

The no-suggests leg is new to this repo — it came with the migration to the org reusable workflow, and it found this immediately. The bug was always there; nothing was testing for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DVjmY3im9Xak7tXLSMGCa