### PR TITLE
fix(tests): survive a library path where the deps sit in the middle

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -140,3 +140,84 @@ jobs:
           # tests for live exercise of those code paths.
           args: 'c("--no-manual", "--as-cran")'
           upload-snapshots: true
+
+  # ---------------------------------------------------------------------------
+  # CRAN's macOS builders and the BLIS check box lay .libPaths() out, under
+  # R CMD check, as
+  #
+  #   [ <pkg>.Rcheck , <contributed lib> , <base lib> ]
+  #
+  # -- every package we depend on sits in a *middle* entry, because the first is
+  # the check library (which holds only Require) and the last is the base R
+  # library (base/recommended only). The default r-lib runner layout in the
+  # matrix above does not have that shape, which is why 2.1.0 was green on all
+  # eleven entries and still came back from CRAN with 11 test failures on four
+  # macOS flavours plus a NOTE.
+  #
+  # This job forces that layout on an ordinary ubuntu runner: dependencies go
+  # into a library of their own, so under check it lands in the middle. The
+  # "Verify" step below asserts the layout really is the reproducing one, so the
+  # job fails loudly rather than quietly stopping being a reproducer.
+  #
+  # error-on: note, and only here: the leftover `<pkg>.Rcheck/pak` that CRAN
+  # reported is a NOTE, and the matrix above (error-on defaults to warning)
+  # would never have failed on it.
+  # ---------------------------------------------------------------------------
+  split-library-check:
+    if: "!contains(github.event.commits[0].message, '[skip-ci]')"
+    runs-on: ubuntu-latest
+    name: ubuntu-latest (release, CRAN-style split library)
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          Ncpus: 2
+          r-version: 'release'
+          use-public-rspm: true
+
+      # Must be set BEFORE setup-r-dependencies so the dependency closure is
+      # installed here and nowhere else. This is the "contributed lib" of the
+      # layout above.
+      - name: Point R_LIBS_USER at a library of its own
+        run: |
+          mkdir -p "$HOME/Rdeps"
+          echo "R_LIBS_USER=$HOME/Rdeps" >> $GITHUB_ENV
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          pak-version: stable
+          extra-packages: |
+            any::rcmdcheck
+
+      # Guard: assert this job still reproduces the CRAN layout. The check is
+      # the failure condition itself -- would the old head+tail narrowing have
+      # hidden Require's own data.table import? If data.table is reachable from
+      # first+last alone, the layout has drifted and this job is no longer
+      # testing anything, so fail rather than pass vacuously.
+      - name: Verify the split-library layout reproduces the CRAN shape
+        shell: Rscript {0}
+        run: |
+          lp <- c(file.path(tempdir(), "Require.Rcheck"), .libPaths())  # as under check
+          cat("simulated .libPaths() under R CMD check:\n"); print(lp)
+          if (length(lp) < 3L)
+            stop("layout drifted: need >= 3 library paths, got ", length(lp))
+          firstAndLast <- unique(c(head(lp, 1), tail(lp, 1)))
+          ip <- rownames(installed.packages(lib.loc = firstAndLast, noCache = TRUE))
+          if ("data.table" %in% ip)
+            stop("layout drifted: data.table is reachable from first+last alone, ",
+                 "so this job no longer reproduces the CRAN macOS/BLIS shape")
+          cat("OK: data.table lives only in a middle library, as on CRAN's macOS builders\n")
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--as-cran")'
+          error-on: '"note"'
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: A single key function, 'Require' that makes rerun-tolerant
 URL: 
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
-Date: 2026-08-29
-Version: 2.1.0.9000
+Date: 2026-09-01
+Version: 2.1.0.9001
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -162,10 +162,50 @@ if (Sys.info()[["user"]] == "achubaty") {
 ##  some of the tests fail because R will load a copy of a package e.g., rlang that is
 ##  in one of the site libraries. Essentially, this is fine for a user, but the tests
 ##  weren't written to accommodate this.
+##
+## Keeping only the first and last path is wrong under R CMD check. There the
+## first path is the `.Rcheck` library, which holds nothing but the package
+## being checked, and every contributed package -- including Require's own
+## `data.table` import -- sits in a *middle* path. That is the layout on CRAN's
+## macOS builders and on the BLIS check box, and on any plain `R CMD check`
+## where R_LIBS_USER is populated. The Suggests loop above has already loaded
+## those namespaces, so `skip_if_not_installed()` and `packageVersion()` keep
+## reporting them as present and the affected tests do not skip; they then fail
+## on `installed.packages(lib.loc = .libPaths())`, which no longer sees them.
+## So still drop the middle paths, but keep back any one of them that is the
+## only remaining source of a package this suite has loaded.
 lp <- .libPaths()
-lp2 <- c(head(lp, 1), tail(lp, 1))
+lp2 <- unique(c(head(lp, 1), tail(lp, 1)))
+libProvides <- function(libs) rownames(installed.packages(lib.loc = libs, noCache = TRUE))
+needed <- intersect(unique(c(loadedNamespaces(), suggests)), libProvides(lp))
+for (libMiddle in setdiff(lp, lp2)) {
+  stillMissing <- setdiff(needed, libProvides(lp2))
+  if (!length(stillMissing)) break
+  ## Only if this path is what supplies something still missing. Testing that,
+  ## rather than just appending until the set is covered, is what keeps a 4- or
+  ## 5-path machine from dragging every intervening site library back in: an
+  ## empty install-target lib or a wholly redundant site lib contributes
+  ## nothing and stays dropped.
+  if (any(stillMissing %in% libProvides(libMiddle)))
+    lp2 <- append(lp2, libMiddle, after = length(lp2) - 1L)
+}
 orig <- setLibPaths(lp2, standAlone = TRUE)
 withr::defer(.libPaths(lp), envir = teardown_env())
+
+## R CMD check makes the `.Rcheck` directory itself `.libPaths()[1]`, so any
+## `Require()`/`Install()` in the suite that does not pass its own `libPaths`
+## treats it as the project library and -- correctly, for a real project lib --
+## symlinks pak into it (`ensurePakInProjectLib()`). What is left behind is
+## `<pkg>.Rcheck/pak`, which "checking for non-standard things in the check
+## directory" reports as a NOTE. It is the suite's detritus, not something a
+## user would ever end up with, so clear it on the way out. Guarded on pak not
+## already being there, so a real installation is never the thing removed.
+if (nzchar(Sys.getenv("_R_CHECK_PACKAGE_NAME_"))) {
+  pakInCheckLib <- file.path(lp[1], "pak")
+  if (!file.exists(pakInCheckLib))
+    withr::defer(unlink(pakInCheckLib, recursive = TRUE, force = TRUE),
+                 envir = teardown_env())
+}
 
 ## PPM binaries on Ubuntu/Debian, for everyone -- this was previously inside the
 ## `emcintir` block, so CI never got it. Without it, Linux resolves everything

--- a/tests/testthat/test-14coverage2_testthat.R
+++ b/tests/testthat/test-14coverage2_testthat.R
@@ -344,7 +344,14 @@ test_that("checkMissingLibPaths round-trip restores .libPaths from .Rprofile", {
   td <- tempdir2("checkMissingRprof")
   rprof <- file.path(td, ".Rprofile")
   origDir <- setwd(td)
-  on.exit({setwd(origDir); unlink(td, recursive = TRUE)}, add = TRUE)
+  ## checkMissingLibPaths() calls setLibPaths() for real, and setLibPaths()
+  ## narrows .libPaths() to the pair it reads back out of the .Rprofile without
+  ## ever putting the original back. Unrestored, that leaks into every test file
+  ## after this one: the contributed library that setup.R deliberately kept (it
+  ## is the only source of data.table and digest under R CMD check) drops off
+  ## the path, and test-15/test-17 then fail against installed.packages().
+  origLibs <- .libPaths()
+  on.exit({setwd(origDir); .libPaths(origLibs); unlink(td, recursive = TRUE)}, add = TRUE)
 
   prevPath <- .libPaths()[1]
   rp_content <- paste(c(


### PR DESCRIPTION
Fixes the CRAN check failures on `Require` 2.1.0:
[check results](https://cran.r-project.org/web/checks/check_results_Require.html) — ERROR on
`r-release-macos-arm64`, `r-release-macos-x86_64`, `r-oldrel-macos-arm64`, `r-oldrel-macos-x86_64`,
a NOTE on `r-devel-linux-x86_64-fedora-gcc`, and both in the BLIS additional-issue run.

Both problems are in the test harness. Nothing in `R/` changes.

## The ERROR — 11 test failures

`tests/testthat/setup.R` narrowed `.libPaths()` to `c(head(lp, 1), tail(lp, 1))`. Under
`R CMD check` the first entry is the `.Rcheck` library, which holds only the package being
checked, and the last is the base R library, which holds only base/recommended packages. So
every contributed package — `data.table` (a `Require` import) and `digest` among them — lives
in a **middle** entry, and was dropped.

The Suggests loop just above has already loaded those namespaces, so `skip_if_not_installed()`
and `packageVersion()` keep reporting them as present and the affected tests do not skip. They
then fail against `installed.packages(lib.loc = .libPaths())`, which can no longer see them.
CRAN's Linux flavours have only two library paths, so nothing is dropped and they stayed green.

The fix still drops middle paths, but keeps back any that is the only remaining source of a
package the suite has loaded. It adds only paths that supply something *still missing*, rather
than adding until the set is covered — that is what stops a 4- or 5-path machine from dragging
every intervening site library back in.

Fixing that alone changed nothing, because `test-14coverage2`'s `checkMissingLibPaths`
round-trip calls `setLibPaths()` for real and never restores `.libPaths()`. That leak was
invisible while `setup.R` had already narrowed to the same two paths; it is restored here too.

## The NOTE — stray `pak` in the check directory

Same origin. `R CMD check` makes the `.Rcheck` directory itself `.libPaths()[1]`, so a
`Require()`/`Install()` without an explicit `libPaths` treats it as the project library and
`ensurePakInProjectLib()` symlinks pak into it — correct behaviour for a real project lib,
detritus here. It is now cleared at teardown, guarded on `_R_CHECK_PACKAGE_NAME_` and on pak
not already being present, so a real installation is never what gets removed.

## Why CI missed it, and what stops that recurring

The existing matrix — macOS included, `--as-cran` included — was green on all eleven entries
for the very commit CRAN rejected: the r-lib runner layout does not have the CRAN shape, and
`error-on` defaults to `warning`, so the `pak` NOTE could never fail a build.

This PR adds a `split-library-check` job that forces the CRAN layout on an ordinary ubuntu
runner (`R_LIBS_USER` pointed at a library of its own *before* `setup-r-dependencies`, so the
deps land in the middle under check), with `error-on: note`. It carries a guard step that fails
if `data.table` ever becomes reachable from first+last alone — so the job cannot quietly drift
into passing vacuously.

## Verification

Layout handling was checked across 1–6 path layouts, including libraries split so that two
different middles each supply part of what is needed, empty install-target libraries
interleaved, and a fully redundant duplicate site library (still dropped, as before).

The teardown was confirmed by an A/B pair of full-suite runs: with `_R_CHECK_PACKAGE_NAME_`
unset the `pak` symlink is created and left behind; with it set, it is gone. So the symlink
really is created by the suite, and the guard really is what removes it.

Full local `R CMD check`: **Status: OK**, and the suite goes from
`FAIL 11 | WARN 0 | SKIP 21 | PASS 669` to `FAIL 0 | WARN 0 | SKIP 21 | PASS 680`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcKo1vhpd1Z11MHRw3veqW
