### PR TITLE
fix(splitGitRepo): take the branch from `@`, not from a fixed position

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Require (development version)
 
+## Bug fixes
+
+* `splitGitRepo()` now takes the branch from whatever follows `@` rather than from
+  a fixed position, so `account/repo/subFolder@branch` no longer reports the
+  subfolder as the branch (and discards the real one). It also returns the
+  `subFolder` it parsed, for both that spelling and `account/repo@branch/subFolder`.
+
 # Require 2.1.0
 
 ## New features

--- a/R/Require-helpers.R
+++ b/R/Require-helpers.R
@@ -874,36 +874,43 @@ splitGitRepo <- function(gitRepo, default = "PredictiveEcology", masterOrMain = 
   gitRepo <- trimVersionNumber(gitRepo)
   hasVersionSpec <- gitRepo != gitRepoOrig
 
-  grSplit <- strsplit(gitRepo, "/|@")
+  ## The branch is whatever follows "@" -- it is not positional. This used to
+  ## split on "/|@" and take the 3rd element as the branch, which is right for
+  ## `Acct/Repo@branch` and `Acct/Repo@branch/subFolder` but wrong for
+  ## `Acct/Repo/subFolder@branch`: there the 3rd element is the subFolder, and
+  ## the real branch was silently discarded. Both spellings are in use.
+  atPos    <- regexpr("@", gitRepo, fixed = TRUE)
+  beforeAt <- ifelse(atPos > 0L, substr(gitRepo, 1L, atPos - 1L), gitRepo)
+  afterAt  <- ifelse(atPos > 0L, substr(gitRepo, atPos + 1L, nchar(gitRepo)), "")
 
-  repo <- lapply(grSplit, function(grsplit) grsplit[[min(2, length(grsplit))]])
-  names(grSplit) <- repo
-  names(repo) <- repo
-  grAcct <- strsplit(gitRepo, "/") # only account and repo
-  lenGT1 <- lengths(grAcct) == 1
-  if (any(lenGT1)) {
-    acct <- default
-    grSplit[lenGT1] <- lapply(grSplit[lenGT1], function(grsplit) append(list(acct), grsplit))
-  } else {
-    acct <- lapply(grSplit, function(grsplit) grsplit[[1]])
-  }
-  lenGT2 <- lengths(grSplit) > 2
-  br <- lapply(grSplit, function(x) list())
-  vs <- br
+  leftSeg  <- strsplit(beforeAt, "/", fixed = TRUE)
+  rightSeg <- strsplit(afterAt, "/", fixed = TRUE)
 
-  if (any(lenGT2)) {
-    br[lenGT2] <- lapply(grSplit[lenGT2], function(grsplit) grsplit[[3]])
-  }
+  repo <- lapply(leftSeg, function(x) x[[min(2L, length(x))]])
+  acct <- lapply(leftSeg, function(x) if (length(x) > 1L) x[[1L]] else default)
+  names(repo) <- names(acct) <- unlist(repo, use.names = FALSE)
 
-  br[!lenGT2] <- "HEAD"
+  br <- lapply(rightSeg, function(r) if (length(r) && nzchar(r[[1L]])) r[[1L]] else "HEAD")
+  names(br) <- names(repo)
 
+  ## Anything past acct/repo on the left, plus anything past the branch on the
+  ## right, is a path to a subfolder within the repo. Returned so callers need
+  ## not re-parse the string; NA when there is none.
+  subFolder <- Map(l = leftSeg, r = rightSeg, f = function(l, r) {
+    extra <- c(if (length(l) > 2L) l[-seq_len(2L)], if (length(r) > 1L) r[-1L])
+    if (length(extra)) paste(extra, collapse = "/") else NA_character_
+  })
+  names(subFolder) <- names(repo)
+
+  vs <- lapply(leftSeg, function(x) list())
+  names(vs) <- names(repo)
   if (any(hasVersionSpec)) {
     versionSpecs <- extractVersionNumber(gitRepoOrig[hasVersionSpec])
     inequs <- extractInequality(gitRepoOrig[hasVersionSpec])
     vs[hasVersionSpec] <- paste0("(", inequs, " ", versionSpecs, ")")
   }
 
-  list(acct = acct, repo = repo, br = br, versionSpec = vs)
+  list(acct = acct, repo = repo, br = br, versionSpec = vs, subFolder = subFolder)
 }
 
 postInstallDESCRIPTIONMods <- function(pkgInstall, libPaths) {

--- a/tests/testthat/test-09splitGitRepo_testthat.R
+++ b/tests/testthat/test-09splitGitRepo_testthat.R
@@ -1,0 +1,58 @@
+## splitGitRepo() had no tests. The branch used to be read positionally -- the
+## 3rd element of strsplit(gitRepo, "/|@") -- which is correct for
+## `Acct/Repo@branch` and `Acct/Repo@branch/subFolder`, but for
+## `Acct/Repo/subFolder@branch` it returned the subFolder as the branch and
+## discarded the real one. Both spellings are in use for a package or SpaDES
+## module living in a subdirectory of its repo.
+
+testthat::test_that("splitGitRepo parses the documented account/repo@branch forms", {
+  g <- Require:::splitGitRepo("PredictiveEcology/Require@development")
+  testthat::expect_identical(g$acct[[1]], "PredictiveEcology")
+  testthat::expect_identical(g$repo[[1]], "Require")
+  testthat::expect_identical(g$br[[1]], "development")
+  testthat::expect_true(is.na(g$subFolder[[1]]))
+
+  ## no branch -> HEAD
+  g <- Require:::splitGitRepo("PredictiveEcology/Require")
+  testthat::expect_identical(g$br[[1]], "HEAD")
+
+  ## bare repo -> default account
+  g <- Require:::splitGitRepo("Require")
+  testthat::expect_identical(g$acct[[1]], "PredictiveEcology")
+  testthat::expect_identical(g$repo[[1]], "Require")
+
+  g <- Require:::splitGitRepo("Require", default = "someoneElse")
+  testthat::expect_identical(g$acct[[1]], "someoneElse")
+})
+
+testthat::test_that("splitGitRepo finds the branch regardless of where '@' falls", {
+  ## subFolder AFTER the branch
+  g <- Require:::splitGitRepo("Acct/Repo@main/subDir")
+  testthat::expect_identical(g$br[[1]], "main")
+  testthat::expect_identical(g$subFolder[[1]], "subDir")
+
+  ## subFolder BEFORE the branch -- this used to yield br = "subDir"
+  g <- Require:::splitGitRepo("Acct/Repo/subDir@main")
+  testthat::expect_identical(g$br[[1]], "main")
+  testthat::expect_identical(g$subFolder[[1]], "subDir")
+
+  ## a nested subFolder path
+  g <- Require:::splitGitRepo("Acct/Repo/a/b@main")
+  testthat::expect_identical(g$br[[1]], "main")
+  testthat::expect_identical(g$subFolder[[1]], "a/b")
+})
+
+testthat::test_that("splitGitRepo keeps the version spec separate", {
+  g <- Require:::splitGitRepo("PredictiveEcology/Require@development (>= 1.0.0)")
+  testthat::expect_identical(g$repo[[1]], "Require")
+  testthat::expect_identical(g$br[[1]], "development")
+  testthat::expect_identical(g$versionSpec[[1]], "(>= 1.0.0)")
+})
+
+testthat::test_that("splitGitRepo is vectorised and names elements by repo", {
+  g <- Require:::splitGitRepo(c("a/b@c", "x/y/z@w"))
+  testthat::expect_identical(unname(unlist(g$repo)), c("b", "y"))
+  testthat::expect_identical(unname(unlist(g$br)), c("c", "w"))
+  testthat::expect_identical(unname(unlist(g$subFolder)), c(NA_character_, "z"))
+  testthat::expect_identical(names(g$repo), c("b", "y"))
+})


### PR DESCRIPTION
Found while diagnosing PredictiveEcology/SpaDES.project#141.

`splitGitRepo()` split on `"/|@"` and read the **3rd element** as the branch:

| spec | split | element 3 |
|---|---|---|
| `Acct/Repo@main` | Acct, Repo, main | `main` ✓ |
| `Acct/Repo@main/sub` | Acct, Repo, main, sub | `main` ✓ |
| `Acct/Repo/sub@main` | Acct, Repo, sub, main | **`sub`** ✗ |

So for a package or SpaDES module in a subdirectory spelled `Acct/Repo/subFolder@branch`, the subfolder came back as the branch and the real branch was discarded.

## Why it was hard to spot

`downloadRepo()` then fetched a branch that doesn't exist, `unzip()` failed with `error 1 in extracting from zip file`, and the caller surfaced only:

> could not be downloaded; does it exist? and are permissions correct?

which reads as an **authentication** failure. In #141 that sent the reporter looking at credentials for a private repo, when the token was fine all along.

## The fix

The branch is now whatever follows `@`, wherever the `@` falls. `subFolder` is also returned — anything past `acct/repo` before the `@`, plus anything past the branch after it; `NA` when there is none — so callers don't re-parse the string.

`subFolder` is an **added** list element, so existing callers indexing by name are unaffected.

```
Acct/Repo@main/subDir   ->  br=main  subFolder=subDir
Acct/Repo/subDir@main   ->  br=main  subFolder=subDir     # was br=subDir
```

## Compatibility

Every documented form is unchanged: bare repo (default account), `account/repo` (HEAD), `account/repo@branch`, and version specs. `man/masterMainToHead.Rd` documents the form as *"account/repo with optional @branch"*, so the positional read was never part of the contract.

Verified that `downloadRepo()` still works for an ordinary public repo, and that the previously-broken spelling now resolves end to end.

## Tests

`splitGitRepo()` had **none**. Adds 21 assertions: the documented forms, both subfolder spellings, nested subfolder paths, version specs, vectorisation, and element naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141xS4r9o76uEgTvzR8qdTP