### PR TITLE
fix: replace browser() calls with stop() on pak error paths

### DIFF
--- a/R/Require2.R
+++ b/R/Require2.R
@@ -2070,7 +2070,13 @@ updatePackagesWithNames <- function(pkgDT, packages) {
     whHasHEAD <- grep(HEADgrepWithParentheses, names(packages))
     packageFullNameWithHEAD <- packages[whHasHEAD]
     if (length(whHasHEAD)) {
-      browser() # this should use `checkHEAD` not custom here
+      ## TODO: this should use `checkHEAD` rather than the custom handling
+      ## below. Left as a note, not a stop(): unlike the two guards in pak.R,
+      ## this browser() was not an error check -- it sat unconditionally on a
+      ## live path, and browser() is a no-op in a non-interactive session, so
+      ## this code runs and works for users today. Converting it to stop()
+      ## would turn a working path into a hard error for anyone passing a named
+      ## package with a HEAD spec.
       pkgDT[
         match(packages[origPackagesHaveNames], packageFullName),
         hasHEAD := packageFullName %in% packageFullNameWithHEAD #

--- a/R/pak.R
+++ b/R/pak.R
@@ -602,8 +602,15 @@ pakRequire <- function(packages, libPaths, doDeps, upgrade, verbose, packagesOri
   }
 
   pkgDT <- try(as.data.table(outs))
+  ## Checked before the subset below, not after: subsetting a try-error object
+  ## errors on its own and the guard never ran.
+  if (is(pkgDT, "try-error"))
+    stop("Require could not assemble pak's install results into a table. ",
+         "This usually means pak returned an unexpected shape for one or more ",
+         "packages. Re-run with `options(Require.verbose = 2)` to see pak's ",
+         "raw output, and please report it at ",
+         "https://github.com/PredictiveEcology/Require/issues with that output.")
   pkgDT <- pkgDT[package != paste0(.txtDummyPackage, "-deps")]
-  if (is(pkgDT, "try-error")) browser()
   setnames(pkgDT, old = c("package", "status"), new = c("Package", "installResult"))
   loadSequence <- match(extractPkgName(packagesOrig), pkgDT$Package)
   loadSequence <- na.omit(loadSequence)
@@ -826,7 +833,12 @@ pakPkgDep <- function(packages, which, simplify, includeSelf, includeBase,
   if (simplify %in% TRUE && any(hasDeps)) {
     deps[hasDeps] <- Map(dep = deps[hasDeps], nam = names(deps)[hasDeps], function(dep, nam) {
       dd <- try(dep$deps)
-      if (is(dd, "try-error")) browser()
+      if (is(dd, "try-error"))
+        stop("Require could not read the dependency list pak returned for ",
+             "package '", nam, "'. Re-run with `options(Require.verbose = 2)` ",
+             "to see pak's raw output, and please report it at ",
+             "https://github.com/PredictiveEcology/Require/issues with that ",
+             "output.")
       dep$deps <- Map(innerDep = dep$deps, outerPkg = dep$package, function(innerDep, outerPkg) {
         if (!nam %in% outerPkg || !any(tolower(unlist(which)) == "suggests")) {
           innerDep[tolower(innerDep$type) %in%


### PR DESCRIPTION
Three `browser()` calls sat in shipped code. `browser()` is a no-op in a
non-interactive session — it prints `debug:` and continues — so none of them
ever stopped anything for a user, which is why they went unnoticed. But each is
a hang in an interactive session.

## The two in `R/pak.R` → `stop()`

Both were genuine `is(x, "try-error")` guards. They now abort with a message
saying what failed, naming the package where applicable, and pointing at
`options(Require.verbose = 2)` and the issue tracker.

`pak.R:606` also had a latent ordering bug:

```r
pkgDT <- try(as.data.table(outs))
pkgDT <- pkgDT[package != paste0(.txtDummyPackage, "-deps")]   # errors first
if (is(pkgDT, "try-error")) browser()                          # unreachable
```

Subsetting a `try-error` throws on its own, so the guard could never fire — and
a `stop()` left in that position would have been equally unreachable. The check
now runs before the subset.

## The one in `R/Require2.R` → removed, TODO kept

Deliberately **not** converted to `stop()`. Unlike the other two it was not an
error check: it sat unconditionally on a live path (`if (length(whHasHEAD))`),
and because `browser()` is a non-interactive no-op that code runs and works
today. A `stop()` there would turn a working path into a hard error for anyone
passing a named package with a HEAD spec. The `## TODO: this should use
checkHEAD` note is preserved.

`grep` confirms no live `browser()` calls remain in `R/`.

Ships in 2.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNLtKFXrNPN2XvuAjsy4Sy