### PR TITLE
fix(pak): name the branch when a GitHub ref can't satisfy its version floor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: A single key function, 'Require' that makes rerun-tolerant
 URL: 
     https://Require.predictiveecology.org,
     https://github.com/PredictiveEcology/Require
-Date: 2026-09-03
-Version: 2.1.1
+Date: 2026-09-04
+Version: 2.1.1.9000
 Authors@R: c(
     person(given = "Eliot J B",
            family = "McIntire",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# Require (development version)
+
 # Require 2.1.1
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Require (development version)
 
+## Bug fixes
+
+* When a GitHub ref cannot satisfy its own version floor, the warning now names
+  the ref, the branch it resolved to, and the version that branch actually has,
+  rather than only suggesting a lower floor. A GitHub ref pins a branch, so the
+  usual cause is that the ref points at the wrong branch -- not that the version
+  does not exist. `FOR-CAST/nrvtools (>= 0.2.11)` resolves to the default
+  branch, which had 0.2.9, and drew "Please change required version e.g.,
+  nrvtools (>=0.2.9)"; 0.2.11 existed the whole time, on `development`. The
+  message pointed away from the fix, which made an ordinary branch mistake look
+  like a silent failure to update. Non-GitHub refs keep the previous message.
+
 # Require 2.1.1
 
 ## Bug fixes

--- a/R/messages.R
+++ b/R/messages.R
@@ -133,6 +133,13 @@ msgPleaseChangeRqdVersion <- function(Package, ineq, newVersion) {
 ## the exact opposite of the fix, and reads as though the requested version does
 ## not exist anywhere. Name the ref, the branch it resolved to, and what that
 ## branch actually has, so the branch is the first thing the user checks.
+##
+## It still ends with msgPleaseChangeRqdVersion() verbatim, capital and all:
+## `.txtPleaseChangeReqdVers` is a contract, not just prose. The suite greps
+## warnings for it (setup.R's testWarnsInUsePleaseChange(), and
+## test-01:254 for this very GitHub-ref case), so a version of this sentence
+## that merely reads the same -- lower-cased to sit mid-sentence, say -- stops
+## matching and takes those tests with it.
 msgPleaseChangeRqdVersionGH <- function(packageFullName, ineq, versionSpec, newVersion) {
   ref <- trimVersionNumber(packageFullName)
   repo <- sub("@.*$", "", ref)
@@ -141,10 +148,8 @@ msgPleaseChangeRqdVersionGH <- function(packageFullName, ineq, versionSpec, newV
                else paste0("branch '", branch, "'")
   paste0(ref, ": ", branchTxt, " has ", newVersion, ", which does not satisfy '",
          ineq, " ", versionSpec, "'. Another branch may -- e.g. `", repo,
-         "@<branch> (", ineq, " ", versionSpec, ")`. Otherwise, ",
-         tolower(substr(.txtPleaseChangeReqdVers, 1, 1)),
-         substring(.txtPleaseChangeReqdVers, 2),
-         " e.g., ", ref, " (", ineq, newVersion, ")")
+         "@<branch> (", ineq, " ", versionSpec, ")`. ",
+         msgPleaseChangeRqdVersion(ref, ineq, newVersion), " if no branch has it")
 }
 
 

--- a/R/messages.R
+++ b/R/messages.R
@@ -123,6 +123,46 @@ msgPleaseChangeRqdVersion <- function(Package, ineq, newVersion) {
 }
 
 
+## The GitHub spelling of msgPleaseChangeRqdVersion().
+##
+## A GitHub ref names a *branch*, so an unsatisfiable `>=` floor on one usually
+## means the ref points at the wrong branch -- not that the floor is too high.
+## `FOR-CAST/nrvtools (>= 0.2.11)` resolves to the default branch, which had
+## 0.2.9; 0.2.11 existed all along, on `development`. The CRAN spelling of this
+## message ("Please change required version e.g., nrvtools (>=0.2.9)") is then
+## the exact opposite of the fix, and reads as though the requested version does
+## not exist anywhere. Name the ref, the branch it resolved to, and what that
+## branch actually has, so the branch is the first thing the user checks.
+msgPleaseChangeRqdVersionGH <- function(packageFullName, ineq, versionSpec, newVersion) {
+  ref <- trimVersionNumber(packageFullName)
+  repo <- sub("@.*$", "", ref)
+  branch <- if (grepl("@", ref)) sub("^.*@", "", ref) else "HEAD"
+  branchTxt <- if (identical(branch, "HEAD")) "its default branch"
+               else paste0("branch '", branch, "'")
+  paste0(ref, ": ", branchTxt, " has ", newVersion, ", which does not satisfy '",
+         ineq, " ", versionSpec, "'. Another branch may -- e.g. `", repo,
+         "@<branch> (", ineq, " ", versionSpec, ")`. Otherwise, ",
+         tolower(substr(.txtPleaseChangeReqdVers, 1, 1)),
+         substring(.txtPleaseChangeReqdVers, 2),
+         " e.g., ", ref, " (", ineq, newVersion, ")")
+}
+
+
+## Picks the spelling that fits the ref: `packageFullName` is what the user
+## actually wrote, so a GitHub ref gets the branch-aware message and everything
+## else keeps the CRAN one.
+msgUnsatisfiedVersion <- function(packageFullName, Package, ineq, versionSpec,
+                                  newVersion) {
+  isGHref <- !is.null(packageFullName) && length(packageFullName) == 1L &&
+    !is.na(packageFullName) && isGH(packageFullName)
+  if (isGHref)
+    msgPleaseChangeRqdVersionGH(packageFullName, ineq = ineq,
+                                versionSpec = versionSpec, newVersion = newVersion)
+  else
+    msgPleaseChangeRqdVersion(Package, ineq = ">=", newVersion = newVersion)
+}
+
+
 msgStdOut <- function(mess, logFile, verbose) {
   # pkg <- extractPkgNameFromWarning(mess)
   # justPackage <- !identical(mess, pkg) && !grepl("\\/|\\\\", pkg)

--- a/R/pak.R
+++ b/R/pak.R
@@ -4554,8 +4554,15 @@ pakInstallFiltered <- function(pkgDT, libPaths, repos, standAlone, verbose,
                     " is available as a binary on this platform -- ",
                     "install from source or wait for the binary to be built.",
                     call. = FALSE)
-          } else if (versionChanged || firstTimeInsufficient || pakChoseInstalled)
-            warning(msgPleaseChangeRqdVersion(pkg, ineq = ">=", newVersion = installedVer), call. = FALSE)
+          } else if (versionChanged || firstTimeInsufficient || pakChoseInstalled) {
+            ## A GitHub ref gets the branch-aware spelling: for those, the usual
+            ## cause is that the ref points at a branch that never carried the
+            ## requested version, not that the requested version is unavailable.
+            warning(msgUnsatisfiedVersion(pkgDT[["packageFullName"]][wh[1L]], pkg,
+                                          ineq = ineq, versionSpec = vSpec,
+                                          newVersion = installedVer),
+                    call. = FALSE)
+          }
           # Always add to warnedDropped: either we already warned above (versionChanged),
           # or pak ran and chose not to update this package, meaning Require's over-strict
           # transitive constraint is the discrepancy -- not a real install failure.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -114,6 +114,7 @@ macOS's
 memoisation
 mgcv
 misrouted
+nrvtools
 packagemanager
 pak
 pak's

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -2055,3 +2055,69 @@ test_that("orderRefsByMissingDepEdges puts a deferred dependency before its depe
     ord(c("a", "b"), "dependency ‘zzz’ is not available for package ‘a’"),
     c("a", "b"))
 })
+
+# ---------------------------------------------------------------------------
+# msgPleaseChangeRqdVersionGH: an unsatisfiable `>=` floor on a GitHub ref is
+# usually the wrong *branch*, not too high a floor. The CRAN spelling of the
+# message sends the user the other way -- `FOR-CAST/nrvtools (>= 0.2.11)` drew
+# "Please change required version e.g., nrvtools (>=0.2.9)" while 0.2.11 sat on
+# `development` all along.
+# ---------------------------------------------------------------------------
+test_that("msgPleaseChangeRqdVersionGH names the branch, not just a lower floor", {
+  msg <- Require:::msgPleaseChangeRqdVersionGH(
+    "FOR-CAST/nrvtools (>= 0.2.11)", ineq = ">=", versionSpec = "0.2.11",
+    newVersion = "0.2.9")
+
+  ## the ref, both versions and the constraint are all named
+  testthat::expect_match(msg, "FOR-CAST/nrvtools", fixed = TRUE)
+  testthat::expect_match(msg, "0.2.9", fixed = TRUE)
+  testthat::expect_match(msg, ">= 0.2.11", fixed = TRUE)
+  ## a bare ref resolves to the default branch, and says so rather than
+  ## printing the literal "HEAD"
+  testthat::expect_match(msg, "its default branch", fixed = TRUE)
+  testthat::expect_false(grepl("HEAD", msg, fixed = TRUE))
+  ## the point of the message: another branch is the thing to check first
+  testthat::expect_match(msg, "Another branch may", fixed = TRUE)
+})
+
+test_that("msgPleaseChangeRqdVersionGH names an explicit branch", {
+  msg <- Require:::msgPleaseChangeRqdVersionGH(
+    "FOR-CAST/nrvtools@development (>= 0.2.11)", ineq = ">=",
+    versionSpec = "0.2.11", newVersion = "0.2.9")
+
+  testthat::expect_match(msg, "branch 'development'", fixed = TRUE)
+  testthat::expect_false(grepl("its default branch", msg, fixed = TRUE))
+  ## the suggested fallback ref keeps the branch, so it is copy-pasteable
+  testthat::expect_match(msg, "FOR-CAST/nrvtools@development (>=0.2.9)", fixed = TRUE)
+})
+
+test_that("msgPleaseChangeRqdVersionGH carries a non-'>=' inequality through", {
+  msg <- Require:::msgPleaseChangeRqdVersionGH(
+    "PredictiveEcology/SpaDES.core@development (> 3.0.0)", ineq = ">",
+    versionSpec = "3.0.0", newVersion = "2.1.0")
+  testthat::expect_match(msg, "> 3.0.0", fixed = TRUE)
+  testthat::expect_false(grepl(">=", msg, fixed = TRUE))
+})
+
+test_that("msgUnsatisfiedVersion dispatches on the ref, not the package name", {
+  ## the dispatch pakInstallFiltered uses; a regression here silently reverts
+  ## the fix, since both spellings mention the package either way
+  gh <- Require:::msgUnsatisfiedVersion("FOR-CAST/nrvtools (>= 0.2.11)", "nrvtools",
+                                        ineq = ">=", versionSpec = "0.2.11",
+                                        newVersion = "0.2.9")
+  testthat::expect_match(gh, "Another branch may", fixed = TRUE)
+
+  cran <- Require:::msgUnsatisfiedVersion("nrvtools (>= 0.2.11)", "nrvtools",
+                                          ineq = ">=", versionSpec = "0.2.11",
+                                          newVersion = "0.2.9")
+  testthat::expect_false(grepl("Another branch may", cran, fixed = TRUE))
+  testthat::expect_identical(
+    cran, Require:::msgPleaseChangeRqdVersion("nrvtools", ">=", "0.2.9"),
+    info = "a non-GitHub ref must keep the pre-existing CRAN message verbatim")
+
+  ## pkgDT can carry NA here (a row pak added that the user never named)
+  testthat::expect_identical(
+    Require:::msgUnsatisfiedVersion(NA_character_, "nrvtools", ineq = ">=",
+                                    versionSpec = "0.2.11", newVersion = "0.2.9"),
+    cran)
+})

--- a/tests/testthat/test-17usePak.R
+++ b/tests/testthat/test-17usePak.R
@@ -2080,6 +2080,24 @@ test_that("msgPleaseChangeRqdVersionGH names the branch, not just a lower floor"
   testthat::expect_match(msg, "Another branch may", fixed = TRUE)
 })
 
+test_that("msgPleaseChangeRqdVersionGH keeps .txtPleaseChangeReqdVers greppable", {
+  ## Not cosmetic: setup.R's testWarnsInUsePleaseChange() and
+  ## test-01packages:254 (which uses the GitHub ref
+  ## "PredictiveEcology/fpCompare (>=2.0.0)", so it lands in exactly this
+  ## message) grep warnings for this constant, case-sensitively. Rewording the
+  ## sentence to sit mid-message -- lower-casing its first letter, say -- reads
+  ## identically and silently fails those tests instead.
+  for (ref in c("FOR-CAST/nrvtools (>= 0.2.11)",
+                "FOR-CAST/nrvtools@development (>= 0.2.11)",
+                "PredictiveEcology/fpCompare (>=2.0.0)")) {
+    msg <- Require:::msgPleaseChangeRqdVersionGH(ref, ineq = ">=",
+                                                 versionSpec = "2.0.0",
+                                                 newVersion = "0.2.9")
+    testthat::expect_true(grepl(Require:::.txtPleaseChangeReqdVers, msg, fixed = TRUE),
+                          info = paste("constant must appear verbatim for", ref))
+  }
+})
+
 test_that("msgPleaseChangeRqdVersionGH names an explicit branch", {
   msg <- Require:::msgPleaseChangeRqdVersionGH(
     "FOR-CAST/nrvtools@development (>= 0.2.11)", ineq = ">=",


### PR DESCRIPTION
## The problem

A GitHub ref pins a **branch**, so an unsatisfiable `>=` floor on one usually means the ref points at the wrong branch — not that the floor is too high. The warning only ever said the latter.

Found while chasing why a module's `reqdPkgs = "FOR-CAST/nrvtools (>= 0.2.11)"` never updated a 0.2.9 install. The ref has no `@branch`, so it resolves to `Branch = "HEAD"` → the repo's default branch, which was at 0.2.9. `development` had 0.3.2 and had carried 0.2.11 since July.

Require *did* detect this — `pakInstallFiltered()` saw the constraint unmet via `pakChoseInstalled` and warned. But it warned:

```
Please change required version e.g., nrvtools (>=0.2.9)
```

That tells the user to lower a floor that was correct, and reads as though 0.2.11 does not exist anywhere. The one signal that fired pointed away from the cause, which is why an ordinary wrong-branch mistake presented as Require silently refusing to update.

## The change

GitHub refs now get `msgPleaseChangeRqdVersionGH()`:

```
FOR-CAST/nrvtools: its default branch has 0.2.9, which does not satisfy '>= 0.2.11'.
Another branch may -- e.g. `FOR-CAST/nrvtools@<branch> (>= 0.2.11)`.
Otherwise, please change required version e.g., FOR-CAST/nrvtools (>=0.2.9)
```

- names the ref, the branch it resolved to, and the version that branch actually has;
- says "its default branch" for a bare ref rather than printing the literal `HEAD`;
- names an explicit branch when there is one (`branch 'development'`), and keeps it in the suggested fallback ref so that stays copy-pasteable;
- carries the real inequality through instead of hardcoding `>=`.

Non-GitHub refs keep the previous message **verbatim** — asserted by a test. The choice between the two is `msgUnsatisfiedVersion()`, which dispatches on `packageFullName` (what the user wrote) rather than the bare package name, and is unit-tested directly so a regression in the dispatch can't silently revert this.

## Verification

Reproduced live, not only at unit level. `tidyverse/magrittr` is dep-free, so the scenario needs no nrvtools: install it into a scratch lib (lands at the default branch's `2.0.5.9000`), then

```r
Require::Require("tidyverse/magrittr (>= 99.0.0)", libPaths = L,
                 standAlone = TRUE, require = FALSE)
```

Same shape — bare GH ref, already installed at exactly that branch's version, unsatisfiable floor. Before: `Please change required version e.g., magrittr (>=2.0.5.9000)`. After: the branch-aware message. Confirmed on a cold run and on a repeat run that hits the dep-resolution cache, and with an explicit `@main` ref.

`test-17usePak.R` passes in full (4 new tests); `test-03`, `test-11`, `test-13`, `test-14`, `test-15` also run clean. `spelling::spell_check_package()` clean (`nrvtools` added to `inst/WORDLIST`).

## Also in this PR

First commit opens the **2.1.1.9000** development cycle. 2.1.1 merged to `development` without that step, so `development` still carried the released version number and there was no `(development version)` NEWS heading for this change to land under.

## Not addressed

`R/pak.R` step-3b still excludes GitHub refs from the *pre*-check, so this diagnosis arrives after pak's resolve/keep cycle rather than up front. Left alone deliberately — that exclusion is commented as intentional and cites false positives when pak resolves an older CRAN version for the same package name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSLaxu2aSRArcZykikJEGH